### PR TITLE
Case mapping for LuaLaTex

### DIFF
--- a/fontspec-code-feat-opentype.dtx
+++ b/fontspec-code-feat-opentype.dtx
@@ -56,13 +56,26 @@
 \@@_define_opentype_feature_group:n {Letters}
 \@@_define_opentype_feature:nnnnn   {Letters} {ResetAll} {} {}
   {
-    +case,+smcp,+pcap,+c2sc,+c2pc,+unic,+rand,
-    -case,-smcp,-pcap,-c2sc,-c2pc,-unic,-rand
+%<LU>  +lower,-lower,+upper,-upper,+case,+cpsp,
+    +smcp,+pcap,+c2sc,+c2pc,+unic,+rand,
+    -smcp,-pcap,-c2sc,-c2pc,-unic,-rand
   }
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\@@_define_opentype_onoffreset:nnnnn {Letters} {Uppercase} {case} {case} {}
+%<*LU>
+\keys_define:nn {fontspec-opentype}
+  {
+    Letters / Uppercase .code:n = {
+      \@@_make_OT_feature:nnn {} {+upper} {+lower}
+      \@@_make_OT_feature:nnn {} {+case} {}
+      \@@_make_OT_feature:nnn {} {+cpsp} {}
+    },
+  }
+\@@_define_opentype_feature:nnnnn {Letters} {UppercaseOff} {} {-upper} {+case,+cpsp}
+\@@_define_opentype_feature:nnnnn {Letters} {UppercaseReset} {} {} {+upper,-upper}
+\@@_define_opentype_onoffreset:nnnnn {Letters} {Lowercase} {} {lower} {+upper,+case,+cpsp}
+%</LU>
 \@@_define_opentype_onoffreset:nnnnn {Letters} {SmallCaps} {smcp} {smcp} {+pcap,+unic}
 \@@_define_opentype_onoffreset:nnnnn {Letters} {PetiteCaps} {pcap} {pcap} {+smcp,+unic}
 \@@_define_opentype_onoffreset:nnnnn {Letters} {UppercaseSmallCaps} {c2sc} {c2sc} {+c2pc,+unic}

--- a/fontspec-doc-opentype.tex
+++ b/fontspec-doc-opentype.tex
@@ -1036,6 +1036,15 @@ will look. OpenType fonts may contain the following options:
 \opt{SmallCaps}, \opt{PetiteCaps},
 \opt{UppercaseSmallCaps}, \opt{UppercasePetiteCaps}, and
 \opt{Unicase}.
+Additionally \opt{Uppercase} and \opt{Lowercase} are supported for all fonts
+in \LuaTeX.
+In contrast to earlier version, the \opt{Uppercase} and \opt{Lowercase} options
+turn the text into uppercase or lowercase and do not require the text to already
+have the right casing. The old behavior of \opt{Uppercase} is available with
+\verb|Style=Uppercase|. When the \opt{Uppercase} option is selected,
+\verb|Style=Uppercase| and \verb|Kerning=Uppercase| are automatically applied if
+supported by the font.
+
 
 \begin{features}{Letters}
 \otf*{SmallCaps}{smcp}
@@ -1043,6 +1052,8 @@ will look. OpenType fonts may contain the following options:
 \otf*{UppercaseSmallCaps}{c2sc}
 \otf*{UppercasePetiteCaps}{c2pc}
 \otf*{Unicase}{unic}
+\otf*{Uppercase}{}
+\otf*{Lowercase}{}
 \cmidrule{2-4}
 \otf{ResetAll}{}
 \end{features}
@@ -1208,7 +1219,7 @@ in \exref{style-uppercase}; note the raised position of the hyphen
 to better match the surrounding letters.
 It will (probably) not actually map letters to uppercase.
  \note{If you want automatic uppercase letters, look to \LaTeX's
-      \cmd\MakeUppercase\ command.}
+      \cmd\MakeUppercase\ command or, when using \LuaTeX, to the \feat{Letters} feature.}
 This option used to be selected under the \feat{Letters} feature, but moved here
 as it generally does not actually affect the letters themselves.
 The \feat{Kerning} feature also contains an \opt{Uppercase} option,


### PR DESCRIPTION
## Status
**READY**

## Description
Expose `luaotfload`'s support for casemapping through the `Letters = Uppercase` / `Letters = Lowercase` features.
This allows to convert text to upper or lowercase on the font level and therefore avoids requiring the mapped content tp be expandable or similar. Additionally this allows to reuse the selected language of a font for applying properly tailored mappings.

Maybe the most interesting aspects:

  1. LuaTeX only.
  2. In addition to triggering the case maping itself, `Letters = Uppercase` automatically applies the equivalent of `Style = Uppercase` and `Kerning = Uppercase`. The idea is that these features are designed to be enabled for uppercase text, so if the text is mapped to uppercase it is a reasonable default to enable them.
  3. This reuses the `Letters = Uppercase` name which used to be what is now known as `Style = Uppercase` and is therefore a breaking change. A different name could be used instead to avoid this, but I think that this approach leads to a more consistent design. Actually mapping the characters to upper/lowercase is much more consistent with the behavior of `Letters = SmallCaps` etc. which also map to small caps instead of requiring text which is already in small caps. Also especially combined with the previous point this shouldn't be a big change even for existing LuaLaTeX documents using `Letters = Uppercase` in the old sense since this feature was already supposed to only be used on uppercase text, so case mapping such text again normally wouldn't have any effect.
  It does break such usage in XeLaTeX documents though. This could be avoided by keeping the old behavior there, but in my opinion having different behavior in both engines would be significantly worse than removing the opinion for XeLaTeX. Especially since the alternative `Style = Uppercase` has been available for more than two years now.
  4. For german and greek, luaotfload will support alternative tailorings (activating the use of the capital eszett and changing the handling of iota subscript's respectively) by passing the strings `de-xeszett` or `el-xiota` to the `upper` (or `lower`, but there these variations don't have an effect) features with the next release. This functionality is currently not exposed.(Mostly because I don't see a sensible interface for this at the moment)
  5. By default the tailoring of the case changing algorithm depends on the `language` passed to `luaotfload`. This can be overwritten by passing a language tag, but as above this isn't exposed. This is potentially problematic because fontspec does not pass the language to luaotfload if the font doesn't contain a language specific feature for the language in question. I think that fontspec should be changed here to always pass on the script and language to make this information available to the font processing, but that should probably be discussed independently.
  This isn't a huge issue since most languages work fine without language specific tailoring anyway.

## Todos
- [ ] Tests added to cover new/fixed functionality
- [x] Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{unicode-math}
\setmainfont{texgyrepagella}[
  Extension = .otf ,
  UprightFont = *-regular.otf ,
  ItalicFont  = *-italic.otf  ,
]
\begin{document}
We need {\addfontfeatures{Letters = Uppercase}you}!
\end{document}
```

