### PR TITLE
Use explicit name: lookups for LuaTeX

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -288,7 +288,8 @@
 %    \begin{macrocode}
 \cs_new:Nn \@@_font_is_name:
   {
-    \cs_set_eq:NN \@@_fontname_wrap:n \use:n
+%<XE>  \cs_set_eq:NN \@@_fontname_wrap:n \use:n
+%<LU>  \cs_set:Npn \@@_fontname_wrap:n ##1 { name: ##1 }
   }
 %    \end{macrocode}
 %

--- a/testfiles/fontload-fontname.luatex.tlg
+++ b/testfiles/fontload-fontname.luatex.tlg
@@ -1,0 +1,16 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+RM:
+TU/TeXGyrePagella(0)/m/n:
+  name:TeXGyrePagella:mode=node;script=latn;language=dflt;+tlig;
+BF:
+TU/TeXGyrePagella(0)/b/n:
+  name:TeXGyrePagella/B:mode=node;script=latn;language=dflt;+tlig;
+IT:
+TU/TeXGyrePagella(0)/m/it:
+  name:TeXGyrePagella/I:mode=node;script=latn;language=dflt;+tlig;
+BFIT:
+TU/TeXGyrePagella(0)/b/it:
+  name:TeXGyrePagella/BI:mode=node;script=latn;language=dflt;+tlig;
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-fontname.lvt
+++ b/testfiles/fontload-fontname.lvt
@@ -1,0 +1,30 @@
+\input{fontspec-testsetup.tex}
+
+\usepackage{fontspec}
+
+\begin{document}
+% Only test in LuaTeX since in XeTeX it's unclear if the fonts ar available
+\LUATEXONLY
+
+\setmainfont{TeX Gyre Pagella}
+
+\MSG{RM:}
+`hello' 123
+\CURRNFSS
+
+\MSG{BF:}
+\bfseries
+`hello' 123
+\CURRNFSS
+
+\MSG{IT:}
+\mdseries\itshape
+`hello' 123
+\CURRNFSS
+
+\MSG{BFIT:}
+\bfseries
+`hello' 123
+\CURRNFSS
+
+\end{document}

--- a/testfiles/fontload-fontname.tlg
+++ b/testfiles/fontload-fontname.tlg
@@ -1,0 +1,5 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+*** LuaTeX-only test ***
+***************
+Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY**

## Description
Use luaotfload's name: lookup for fontname based lookups instead of letting luaotfload guess. This is faster and more reliable if other files with problematic names are lying around.
Fixes #442.

## Todos
- [x] Tests added to cover new/fixed functionality
- n/a Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{unicode-math}
\setmainfont{texgyrepagella}
\begin{document}
Should now start with \texttt{name:}: \fontname \font
\end{document}
```

