### PR TITLE
Implement OnlyKpse for LuaTeX

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -282,9 +282,9 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_font_is_file:,\@@_font_is_name:}
+% \begin{macro}{\@@_font_is_file:,\@@_font_is_name:,\@@_font_is_kpse:}
 % The \cs{@@_fontname_wrap:n} command takes the font name and either passes it through unchanged or wraps it in the syntax for loading a font `by filename'.
-% \XeTeX's syntax is followed since \pkg{luaotfload} provides compatibility.
+% For Lua\TeX\ there are two kinds kinds of filename based loading supported: Regular filename lookups which include system fonts and lookups restricted to kpse.
 %    \begin{macrocode}
 \cs_new:Nn \@@_font_is_name:
   {
@@ -297,6 +297,16 @@
   {
     \cs_set:Npn \@@_fontname_wrap:n ##1 { [ \l_@@_font_path_tl ##1 ] }
   }
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*LU>
+\cs_new:Nn \@@_font_is_kpse:
+  {
+    \cs_set:Npn \@@_fontname_wrap:n ##1 { kpse: ##1 }
+  }
+%</LU>
+%<XE>\cs_new_eq:NN \@@_font_is_kpse: \@@_font_is_file:
 %    \end{macrocode}
 % \end{macro}
 %

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -63,7 +63,13 @@
     \bool_set_true:N \l_@@_noit_bool
     \bool_set_true:N \l_@@_external_bool
     \tl_set:Nn \l_@@_font_path_tl {#1}
-    \@@_font_is_file:
+    \bool_lazy_and:nnTF { \l_@@_external_kpse_bool } { \tl_if_empty_p:N \l_@@_font_path_tl }
+      {
+        \@@_font_is_kpse:
+      }
+      {
+        \@@_font_is_file:
+      }
 %<*XE>
     \keys_set:nn {fontspec-renderer} {Renderer=OpenType}
 %</XE>
@@ -87,6 +93,22 @@
   }
 \tl_clear:N \l_@@_extension_tl
 \@@_keys_define_code:nnn {fontspec} {Extension} {}
+%    \end{macrocode}
+%
+% \paragraph{\feat{KpseOnly}}
+% If the font is specified by filename, only search for it through kpse.
+% \XeTeX\ does not support finding system fonts by filename so this is always implicitly set
+% there.
+%    \begin{macrocode}
+\@@_keys_define_code:nnn {fontspec-preparse-external} {KpseOnly}
+  {
+    \bool_set_true:N \l_@@_external_kpse_bool
+    \bool_if:NT \l_@@_external_bool
+      {
+        \@@_font_is_kpse:
+      }
+  }
+\@@_keys_define_code:nnn {fontspec} {KpseOnly} {}
 %    \end{macrocode}
 %
 %

--- a/fontspec-code-vars.dtx
+++ b/fontspec-code-vars.dtx
@@ -63,6 +63,7 @@
 \bool_new:N \l_@@_defining_encoding_bool
 \bool_new:N \l_@@_scriptlang_exist_bool
 \bool_new:N \g_@@_em_normalise_slant_bool
+\bool_new:N \l_@@_external_kpse_bool
 \bool_new:N \l_@@_proceed_bool
 %    \end{macrocode}
 %

--- a/fontspec-doc-fontsel.tex
+++ b/fontspec-doc-fontsel.tex
@@ -129,6 +129,7 @@ wish to have them all installed in your system's font directories.
 In this case, it is more convenient to load them from a different location on your disk.
 This technique is also necessary in \XeTeX\ when loading OpenType fonts that are present within your \TeX\ distribution, such as \path{/usr/local/texlive/2013/texmf-dist/fonts/opentype/public}.
 Fonts in such locations are visible to \XeTeX\ but cannot be loaded by font name, only file name; \LuaTeX\ does not have this restriction.
+(If you for some reason want to restrict the fonts to the ones provided by your \TeX\ distribution even though you are using \LuaTeX\ you can use the \texttt{KpseOnly} option)
 
 When selecting fonts by file name, any font that can be found in the default
 search paths may be used directly (including in the current directory)


### PR DESCRIPTION
## Status
**READY**

## Description
Add an option `KpseOnly` to restrict font searches to fonts in the TeX directories as discussed in #413.
In XeTeX the option works too but is ignored.

## Todos
- [ ] Tests added to cover new/fixed functionality
- [x] Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{unicode-math}
\setmainfont{texgyrepagella}[
  KpseOnly,
  Extension = .otf ,
  UprightFont = *-regular.otf ,
  ItalicFont  = *-italic.otf  ,
]
\begin{document}
hello \emph{hello}
\end{document}
```

