### PR TITLE
add missing error function, issue #423

### DIFF
--- a/fontspec-code-msg.dtx
+++ b/fontspec-code-msg.dtx
@@ -13,6 +13,7 @@
 \cs_new:Npn \@@_error:n     { \msg_error:nn     {fontspec} }
 \cs_new:Npn \@@_error:nn    { \msg_error:nnn    {fontspec} }
 \cs_new:Npn \@@_error:nx    { \msg_error:nnx    {fontspec} }
+\cs_new:Npn \@@_error:nxx   { \msg_error:nnxx    {fontspec} }
 \cs_new:Npn \@@_warning:n   { \msg_warning:nn   {fontspec} }
 \cs_new:Npn \@@_warning:nx  { \msg_warning:nnx  {fontspec} }
 \cs_new:Npn \@@_warning:nxx { \msg_warning:nnxx {fontspec} }


### PR DESCRIPTION
## Status
**READY**

## Description
fix issue #423 

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{fontspec}
\setmainfont[HyphenChar="1000]{FreeSerif}  % It doesn't exist

\begin{document}

blub
\end{document}
```

