### PR TITLE
Use STIXTwo instead of STIX2 in tests

### DIFF
--- a/testfiles/script-lang-trk.luatex.tlg
+++ b/testfiles/script-lang-trk.luatex.tlg
@@ -1,13 +1,13 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 DEFAULT
-TU/STIX2Text-Regular.otf(0)/m/n:
-  [STIX2Text-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;
+TU/STIXTwoText-Regular.otf(0)/m/n:
+  [STIXTwoText-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 SCRIPT DFLT
-TU/STIX2Text-Regular.otf(1)/m/n:
-  [STIX2Text-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;
+TU/STIXTwoText-Regular.otf(1)/m/n:
+  [STIXTwoText-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 LANG TRK
-TU/STIX2Text-Regular.otf(2)/m/n:
-  [STIX2Text-Regular.otf]:mode=node;script=latn;language=TRK;+tlig;
+TU/STIXTwoText-Regular.otf(2)/m/n:
+  [STIXTwoText-Regular.otf]:mode=node;script=latn;language=TRK;+tlig;
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/script-lang-trk.lvt
+++ b/testfiles/script-lang-trk.lvt
@@ -6,15 +6,15 @@
 \begin{document}
 
 \MSG{DEFAULT}
-\setmainfont{STIX2Text-Regular.otf}
+\setmainfont{STIXTwoText-Regular.otf}
 \CURRNFSS
 
 \MSG{SCRIPT DFLT}
-\setmainfont{STIX2Text-Regular.otf}[Script=Latin]
+\setmainfont{STIXTwoText-Regular.otf}[Script=Latin]
 \CURRNFSS
 
 \MSG{LANG TRK}
-\setmainfont{STIX2Text-Regular.otf}[Script=Latin,Language=Turkish]
+\setmainfont{STIXTwoText-Regular.otf}[Script=Latin,Language=Turkish]
 \CURRNFSS
 
 \end{document}

--- a/testfiles/script-lang-trk.tlg
+++ b/testfiles/script-lang-trk.tlg
@@ -1,13 +1,13 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 DEFAULT
-TU/STIX2Text-Regular.otf(0)/m/n:
-  "[STIX2Text-Regular.otf]/OT:script=latn;language=dflt;mapping=tex-text;"
+TU/STIXTwoText-Regular.otf(0)/m/n:
+  "[STIXTwoText-Regular.otf]/OT:script=latn;language=dflt;mapping=tex-text;"
 SCRIPT DFLT
-TU/STIX2Text-Regular.otf(1)/m/n:
-  "[STIX2Text-Regular.otf]/OT:script=latn;language=dflt;mapping=tex-text;"
+TU/STIXTwoText-Regular.otf(1)/m/n:
+  "[STIXTwoText-Regular.otf]/OT:script=latn;language=dflt;mapping=tex-text;"
 LANG TRK
-TU/STIX2Text-Regular.otf(2)/m/n:
-  "[STIX2Text-Regular.otf]/OT:script=latn;language=TRK;mapping=tex-text;"
+TU/STIXTwoText-Regular.otf(2)/m/n:
+  "[STIXTwoText-Regular.otf]/OT:script=latn;language=TRK;mapping=tex-text;"
 ***************
 Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY**

## Description
See #465: Call the font with the name STIXTwoText instead of STIX2Text to match the official filename.

## Todos
- n/a Tests added to cover new/fixed functionality
- n/a Documentation if necessary
- n/a Code follows expl3 style guidelines