### PR TITLE
Variable

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -445,7 +445,7 @@
     \prop_gput:cnx {g_@@_fontinfo_ \g_@@_nfss_family_tl _prop} {fontdef}
       {
         \@@_construct_font_call:nn {\l_fontspec_fontname_tl}
-          { \l_@@_pre_feat_sclist \g_@@_rawfeatures_sclist }
+          { \l_@@_pre_feat_sclist \g_@@_rawfeatures_sclist \@@_get_variations: }
       }
     \prop_gput:cnV {g_@@_fontinfo_ \g_@@_nfss_family_tl _prop} {script-num} \l_@@_script_int
     \prop_gput:cnV {g_@@_fontinfo_ \g_@@_nfss_family_tl _prop} {lang-num}   \l_@@_language_int
@@ -790,7 +790,7 @@
 %<debug>\typeout{====~Setup~NFSS~shape:~<\l_@@_size_tl>~\l_fontspec_fontname_tl}
 
     \@@_get_features:n { #2 , #3 , #4 }
-%<debug>\typeout{====~Gathered~features:~\g_@@_rawfeatures_sclist}
+%<debug>\typeout{====~Gathered~features:~\g_@@_rawfeatures_sclist \@@_get_variations:}
 
     \tl_if_empty:NF \l_@@_scale_tl
       {
@@ -801,7 +801,7 @@
       {
         <\l_@@_size_tl> \l_@@_scale_tl
         \@@_construct_font_call:nn { \l_fontspec_fontname_tl }
-          { \l_@@_pre_feat_sclist \g_@@_rawfeatures_sclist }
+          { \l_@@_pre_feat_sclist \g_@@_rawfeatures_sclist \@@_get_variations: }
       }
   }
 %    \end{macrocode}
@@ -1052,6 +1052,30 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\@@_get_variations:}
+% \cmd{\@@_get_variations:} builds the feature string representing the
+% current variation instance and/or axis settings.
+%    \begin{macrocode}
+\cs_new:Nn \@@_format_axis:nn
+  {
+    #1 = #2 ,
+  }
+\cs_new:Nn \@@_get_variations:
+  {
+    \tl_if_empty:NF \g_@@_instance_tl
+      {
+        instance = { \g_@@_instance_tl };
+      }
+      \prop_if_empty:NF \g_@@_rawvariations_prop
+      {
+        axis = {
+          \prop_map_function:NN \g_@@_rawvariations_prop \@@_format_axis:nn
+        };
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsection{Initialisation}
 %
 % \begin{macro}{\@@_init:}
@@ -1089,6 +1113,8 @@
 \cs_new:Nn \@@_init_fontface:
   {
     \tl_gclear:N \g_@@_rawfeatures_sclist
+    \prop_gclear:N \g_@@_rawvariations_prop
+    \tl_gclear:N \g_@@_instance_tl
     \tl_clear:N \l_@@_scale_tl
     \tl_set_eq:NN \l_@@_opacity_tl \c_@@_opacity_tl
     \tl_set_eq:NN \l_@@_hexcol_tl \c_@@_hexcol_tl

--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -1056,9 +1056,10 @@
 % \cmd{\@@_get_variations:} builds the feature string representing the
 % current variation instance and/or axis settings.
 %    \begin{macrocode}
+\cs_generate_variant:Nn \tl_tail:n { e }
 \cs_new:Nn \@@_format_axis:nn
   {
-    #1 = #2 ,
+    , #1 = #2
   }
 \cs_new:Nn \@@_get_variations:
   {
@@ -1069,7 +1070,9 @@
       \prop_if_empty:NF \g_@@_rawvariations_prop
       {
         axis = {
-          \prop_map_function:NN \g_@@_rawvariations_prop \@@_format_axis:nn
+          \tl_tail:e {
+            \prop_map_function:NN \g_@@_rawvariations_prop \@@_format_axis:nn
+          }
         };
       }
   }

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -809,6 +809,15 @@
   }
 %    \end{macrocode}
 %
+% \subsubsection{Variation instances}
+%
+%    \begin{macrocode}
+\@@_keys_define_code:nnn {fontspec-opentype} {Instance}
+  {
+    \tl_gset:Nn \g_@@_instance_tl {#1}
+  }
+%    \end{macrocode}
+%
 % \subsubsection{Font transformations}
 % These are to be specified to apply directly to a font shape:
 %    \begin{macrocode}

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -774,6 +774,7 @@
   }
 %</XE>
 %<LU>\@@_define_opentype_variation_axis:nn {Width} {wdth}
+\@@_define_opentype_variation_axis:nn {Slant} {slnt}
 \@@_keys_define_code:nnn {fontspec} {OpticalSize}
 %<*XE>
   {

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -760,14 +760,20 @@
 % \subsubsection{Continuous font axes}
 %
 %    \begin{macrocode}
+%<*XE>
 \@@_keys_define_code:nnn {fontspec} {Weight}
   {
     \@@_update_featstr:n{weight=#1}
   }
+%</XE>
+%<LU>\@@_define_opentype_variation_axis:nn {Weight} {wght}
+%<*XE>
 \@@_keys_define_code:nnn {fontspec} {Width}
   {
     \@@_update_featstr:n{width=#1}
   }
+%</XE>
+%<LU>\@@_define_opentype_variation_axis:nn {Width} {wdth}
 \@@_keys_define_code:nnn {fontspec} {OpticalSize}
 %<*XE>
   {
@@ -793,6 +799,14 @@
     \tl_set:Nn \l_@@_optical_size_tl {/ S = #1}
   }
 %</LU>
+%    \end{macrocode}
+%
+% For other potentially font specific variation axes, there is a raw setter available:
+%    \begin{macrocode}
+\@@_keys_define_code:nnn {fontspec-opentype} {RawAxis}
+  {
+    \prop_gput_from_keyval:Nn \g_@@_rawvariations_prop {#1}
+  }
 %    \end{macrocode}
 %
 % \subsubsection{Font transformations}

--- a/fontspec-code-opentype.dtx
+++ b/fontspec-code-opentype.dtx
@@ -10,6 +10,22 @@
 %
 %
 %
+% \begin{macro}{\@@_define_opentype_variation_axis:nn}
+%    \begin{macrocode}
+\cs_new:Nn \@@_define_opentype_variation_axis:nn
+  {
+    \keys_define:nn {fontspec-opentype}
+      {
+        #1 .code:n = {
+          \prop_gput:Nnn \g_@@_rawvariations_prop { #2 } { ##1 }
+        },
+        #1 .value_required:n = true,
+        #1 .groups:n = {opentype},
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\@@_define_opentype_feature_group:n}
 %    \begin{macrocode}
 \cs_new:Nn \@@_define_opentype_feature_group:n

--- a/fontspec-code-vars.dtx
+++ b/fontspec-code-vars.dtx
@@ -151,6 +151,7 @@
 \prop_new:N \g_@@_strong_prop
 \prop_new:N \g_@@_fontid_family_prop
 \prop_new:N \g_@@_family_int_prop
+\prop_new:N \g_@@_rawvariations_prop
 %    \end{macrocode}
 %
 % \paragraph{Token lists}
@@ -288,6 +289,7 @@
 \tl_new:N \l_@@_punctspace_adjust_tl
 \tl_new:N \l_@@_wordspace_adjust_tl
 \tl_new:N \l_@@_postadjust_tl
+\tl_new:N \g_@@_instance_tl
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -608,6 +608,64 @@ This functionality is not generally used for lowercase text in modern typesettin
 In particular, small amounts of letter spacing can be very useful, when setting small caps or all caps titles.
 Also see the OpenType \opt{Uppercase} option of the \feat{Letters} feature (\vref{sec:letters}).
 
+
+\section{Variable fonts} \label{sec:variable}
+
+OpenType variable fonts and Multiple Master fonts are parameterised over
+orthogonal font axes, allowing continuous selection along such features
+as weight, width, and optical size.
+
+
+\subsection{Optical font sizes} \label{sec:aat-opticalsize}
+Whereas traditional OpenType fonts will have only a few separate
+optical sizes, a Variable or Multiple Master font's optical size can be
+specified over a continuous range. Unfortunately, this flexibility makes
+it harder to create an automatic interface through \LaTeX, and the
+optical size for a Variable or Multiple Master font must always be specified
+explicitly.
+\begin{Verbatim}
+  \fontspec{Minion MM Roman}[OpticalSize=11]
+   MM optical size test                    \\
+  \fontspec{Minion MM Roman}[OpticalSize=47]
+   MM optical size test                    \\
+  \fontspec{Minion MM Roman}[OpticalSize=71]
+   MM optical size test                    \\
+\end{Verbatim}
+
+
+\subsection{Weight} \label{sec:variable-weight}
+For fonts with a variable weight axis, the weight can be specified through the
+\feat{Weight} feature. The value should be between 0 and 1000, where typically
+400 corresponds to regular wight and 700 is a bold font.
+\begin{Verbatim}
+  \fontspec{Source Serif Variable}[Weight=700]
+  Bold                                     \\
+  \fontspec{Source Serif Variable}[Weight=200]
+  Extra Light                              \\
+\end{Verbatim}
+
+
+\subsection{Width} \label{sec:variable-width}
+Similarly, the \feat{Width} feature allows specifying the value of the width axis,
+where the value is a percentage of normal width.
+\begin{Verbatim}
+  \fontspec{Noto Serif}[Width=100]
+  Normal Width                             \\
+  \fontspec{Noto Serif}[Width=75]
+  Condensed                                \\
+\end{Verbatim}
+
+\subsection{Other axes} \label{sec:variable-raw}
+For OpenType variable fonts, additional axis values can be specified
+if the four letter tag of these axes is known.
+Than their value can be set with the \feat{RawAxis} feature:
+\begin{Verbatim}
+  \fontspec{Noto Serif}[RawAxis={CTGR=100}]
+  Maximal contrast                        \\
+  \fontspec{Noto Serif}[RawAxis={CTGR=0}]
+  Regular contrast                        \\
+\end{Verbatim}
+
 \end{document}
 
 % /©

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -683,6 +683,15 @@ Than their value can be set with the \feat{RawAxis} feature:
   Regular contrast                        \\
 \end{Verbatim}
 
+\subsection{Instances} \label{sec:variable-instances}
+Instead of manually setting axis values, many fonts contain named instances which are predefined settings of all axes.
+
+To select such an instance, the \feat{Instance} feature can be used:
+\begin{Verbatim}
+  \fontspec{Noto Serif}[Instance=ExtraCondensed Bold]
+  This is in extra condensed bold.
+\end{Verbatim}
+
 \end{document}
 
 % /©

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -615,6 +615,8 @@ OpenType variable fonts and Multiple Master fonts are parameterised over
 orthogonal font axes, allowing continuous selection along such features
 as weight, width, and optical size.
 
+Currently OpenType variable fonts are only supported in \LuaTeX, while
+Multiple Master fonts only work with \XeTeX.
 
 \subsection{Optical font sizes} \label{sec:aat-opticalsize}
 Whereas traditional OpenType fonts will have only a few separate

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -657,6 +657,21 @@ where the value is a percentage of normal width.
   Condensed                                \\
 \end{Verbatim}
 
+\subsection{Slant} \label{sec:variable-slant}
+Also fonts with a slant axis can be controlled with the \feat{Slant} feature.
+In a standard compliant font the value should specify the clockwise angle in degree
+the glyphs are slanted. Therefore for a typical forward leaning slanted font, a
+negative value should be passed.
+
+Many fonts use this feature in non-standard ways, so you might have to experiment
+a bit with the value.
+\begin{Verbatim}
+  \fontspec{Roboto Flex}[Slant=0]
+  Upright                            \\
+  \fontspec{Roboto Flex}[Slant=-5]
+  Slanted                            \\
+\end{Verbatim}
+
 \subsection{Other axes} \label{sec:variable-raw}
 For OpenType variable fonts, additional axis values can be specified
 if the four letter tag of these axes is known.

--- a/fontspec-doc-xetex.tex
+++ b/fontspec-doc-xetex.tex
@@ -58,27 +58,6 @@ by \pkg{fontspec} before all others and will automatically and without warning
 select the \opt{OpenType} renderer.}
 
 
-\subsection{Optical font sizes} \label{sec:aat-opticalsize}
-
-Multiple Master fonts are parameterised over
-orthogonal font axes, allowing continuous selection along such
-features as weight, width, and optical size.
-Whereas an OpenType font will have only a few separate
-optical sizes, a Multiple Master font's optical size can be
-specified over a continuous range. Unfortunately, this flexibility makes
-it harder to create an automatic interface through \LaTeX, and the
-optical size for a Multiple Master font must always be specified
-explicitly.
-\begin{Verbatim}
-  \fontspec{Minion MM Roman}[OpticalSize=11]
-   MM optical size test                    \\
-  \fontspec{Minion MM Roman}[OpticalSize=47]
-   MM optical size test                    \\
-  \fontspec{Minion MM Roman}[OpticalSize=71]
-   MM optical size test                    \\
-\end{Verbatim}
-
-
 \subsection{Vertical typesetting}
 
 \XeTeX\ provides for vertical typesetting simply with the ability to rotate

--- a/testfiles/fontload-variable.luatex.tlg
+++ b/testfiles/fontload-variable.luatex.tlg
@@ -1,0 +1,9 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Default: 9.45pt
+Bold: 9.86pt
+Black: 10.16pt
+Black condensed: 8.98pt
+Extracondensed Bold: 8.07pt
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-variable.lvt
+++ b/testfiles/fontload-variable.lvt
@@ -1,0 +1,33 @@
+\input{fontspec-testsetup.tex}
+
+\usepackage{fontspec}
+\usepackage{iftex}
+\ifluahbtex
+  \defaultfontfeatures{Renderer=HarfBuzz}
+\fi
+
+\begin{document}
+
+\START
+
+\fontspec{NotoSerif-VF.ttf}
+\setbox0\hbox{m}
+\MSG{Default: \the\wd0}
+
+\fontspec[Weight=700]{NotoSerif-VF.ttf}
+\setbox0\hbox{m}
+\MSG{Bold: \the\wd0}
+
+\fontspec[Weight=900]{NotoSerif-VF.ttf}
+\setbox0\hbox{m}
+\MSG{Black: \the\wd0}
+
+\fontspec[Weight=900, Width=75]{NotoSerif-VF.ttf}
+\setbox0\hbox{m}
+\MSG{Black condensed: \the\wd0}
+
+\fontspec[Instance=ExtraCondensed Bold]{NotoSerif-VF.ttf}
+\setbox0\hbox{m}
+\MSG{Extracondensed Bold: \the\wd0}
+
+\end{document}

--- a/testfiles/fontload-variable.xetex.tlg
+++ b/testfiles/fontload-variable.xetex.tlg
@@ -1,0 +1,9 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Default: 9.45pt
+Bold: 9.45pt
+Black: 9.45pt
+Black condensed: 9.45pt
+Extracondensed Bold: 9.45pt
+***************
+Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY/FOR DISCUSSION**

## Description
Add an interface for loading variable fonts under LuaLaTeX.

While fontspec already had undocumented `Width` and `Weight` font features (probably for Multiple Master fonts), these didn't set the current values to work for Variable fonts with luaotfload. Also there was no interface to set arbitrary axes. This was particularly problematic since `luaotfload` expects all axis values to be passed in a single `axis` feature, so using `RawFeature` to set one axis overwrites the values for all previously set axes.

Therefore this PR, besides making `Weight` and `Width` compatible with luaotfload and Variable fonts, adds a companion to `RawFeature` called `RawAxis` which allows to set arbitrary axis values.

## Todos
- [x] Tests added to cover new/fixed functionality
- [x] Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{unicode-math}
\setmainfont{NotoSerif}[
  Extension = .ttf,
  UprightFont = *-VF,
  ItalicFont  = *-Italic-VF,
  Weight = 200,
  Width = 75,
  RawAxis = {CTGR=100},
]
\begin{document}
This is the Extra Light Condensed Display style.
\end{document}
```

