### PR TITLE
Make *Features work in \defaultfontfeatures

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -352,7 +352,7 @@
     \bool_if:NTF \l_@@_ot_bool
       {
 %<debug>  \typeout{::: Setting~ keys~ for~ OpenType~ font~ features:~"\l_@@_keys_leftover_clist"}
-        \keys_set:nV {fontspec-opentype} \l_@@_keys_leftover_clist
+        \keys_set_known:nV {fontspec-opentype} \l_@@_keys_leftover_clist
       }
       {
 %<debug>  \typeout{::: Setting~ keys~ for~ AAT/Graphite~ font~ features:~"\l_@@_keys_leftover_clist"}
@@ -362,7 +362,7 @@
 %</XE>
 %<*LU>
 %<debug>  \typeout{::: Setting~ keys~ for~ OpenType~ font~ features:~"\l_@@_keys_leftover_clist"}
-    \keys_set:nV {fontspec-opentype} \l_@@_keys_leftover_clist
+    \keys_set_known:nV {fontspec-opentype} \l_@@_keys_leftover_clist
 %</LU>
 
     \tl_if_empty:NF \l_@@_mapping_tl

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -338,37 +338,37 @@
 % \subsubsection{Preparsed font features}
 %
 %    \begin{macrocode}
-\@@_keys_define_code:nnn {fontspec-opentype} {UprightFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {UprightFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_up_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {BoldFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {BoldFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bf_clist {#1}
 %  \prop_put:NxV \l_@@_nfss_prop
 %     {BoldFont-\g_@@_curr_series_tl} \l_@@_curr_bfname_tl
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {ItalicFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {ItalicFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_it_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {BoldItalicFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {BoldItalicFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bfit_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {SlantedFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {SlantedFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_sl_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {BoldSlantedFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {BoldSlantedFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bfsl_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {SwashFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {SwashFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_sw_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-opentype} {BoldSwashFeatures}
+\@@_keys_define_code:nnn {fontspec-preparse} {BoldSwashFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bfsw_clist {#1}
   }

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -338,37 +338,37 @@
 % \subsubsection{Preparsed font features}
 %
 %    \begin{macrocode}
-\@@_keys_define_code:nnn {fontspec-preparse} {UprightFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {UprightFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_up_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {BoldFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {BoldFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bf_clist {#1}
 %  \prop_put:NxV \l_@@_nfss_prop
 %     {BoldFont-\g_@@_curr_series_tl} \l_@@_curr_bfname_tl
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {ItalicFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {ItalicFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_it_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {BoldItalicFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {BoldItalicFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bfit_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {SlantedFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {SlantedFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_sl_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {BoldSlantedFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {BoldSlantedFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bfsl_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {SwashFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {SwashFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_sw_clist {#1}
   }
-\@@_keys_define_code:nnn {fontspec-preparse} {BoldSwashFeatures}
+\@@_keys_define_code:nnn {fontspec-opentype} {BoldSwashFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bfsw_clist {#1}
   }


### PR DESCRIPTION
## Status
For discussion.

## Description
Potential fix for bug #436.

I do *not* claim this is the correct fix, in fact I'm pretty sure it is not. My intention is to draw attention to this 19 month old bug report and offer a possible explanation for what is going wrong, because it also affects me and I would like to see it fixed.

I have no clue whatsoever about LaTeX 3 code, keyval, or anything else; my expertise *just* reaches `s/preparse/opentype/` as shown here.

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [ ] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
See bug #436.

