### PR TITLE
Added a Scale=MatchAveragecase option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 Change history
 ==============
-
+  * Added a `Scale=MatchAveragecase` paramater which averages `Scale=MatchLowercase` and `Scale=MatchUppercase`.
 ## v2.8a (2022/01/15)
 
   * Add `SwashFont` and `BoldSwashFont` features to support LaTeX's now-builtin `\textsw`

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -485,8 +485,8 @@
 %
 % \paragraph{Scale}
 % If the input isn't one of the pre-defined string options, then
-% it's gotta be numerical. \cs{fontspec_calc_scale:n} does all the work in
-% the auto-scaling cases.
+% it's gotta be numerical. \cs{fontspec_calc_scale:n} and \cs{fontspec_calc_scale:nn}
+% do all the work in the auto-scaling cases.
 %    \begin{macrocode}
 \@@_keys_define_code:nnn {fontspec} {Scale}
   {
@@ -494,8 +494,10 @@
       {
         {MatchLowercase} { \@@_calc_scale:n {5} }
         {MatchUppercase} { \@@_calc_scale:n {8} }
+        {MatchAveragecase} { \@@_calc_scale:nn {5} {8} }
       }
       { \tl_set:Nx \l_@@_scale_tl {#1} }
+      \@@_info:n {set-scale}
   }
 %    \end{macrocode}
 %
@@ -542,7 +544,6 @@
                        \dim_to_fp:n {\l_@@_tmpb_dim}   }
         }
 
-      \@@_info:n {set-scale}
       \exp_args:NNNx
     \group_end:
     \tl_set:Nx \l_@@_scale_tl { \l_@@_scale_tl }
@@ -551,6 +552,26 @@
 % \end{macro}
 %
 %
+% \begin{macro}{\@@_calc_scale:nn}
+% This macro calls \cs{fontspec_calc_scale:n} twice
+% and then sets the scale to the average of the two results.
+%    \begin{macrocode}
+\cs_new:Nn \@@_calc_scale:nn
+{
+    \group_begin:
+      \__fontspec_calc_scale:n {#1}
+      \tl_set_eq:NN \l_@@_tmp_tl \l_@@_scale_tl
+      \__fontspec_calc_scale:n {#2}
+      \tl_set:Nx \l_@@_scale_tl
+        {
+          \fp_eval:n { (\l_@@_tmp_tl + \l_@@_scale_tl)/2 }
+        }
+      \exp_args:NNNx
+    \group_end:
+    \tl_set:Nx \l_@@_scale_tl { \l_@@_scale_tl }
+  }
+%    \end{macrocode}
+% \end{macro}
 % \begin{macro}{\@@_set_font_dimen:NnN}
 % This function sets the dimension |#1| (for font |#3|) to `fontdimen' |#2|
 % for either font dimension 5 (x-height) or 8 (cap-height). If, for some

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -369,7 +369,8 @@ while defining opacity in this way, if you like.
 \cmdbox{
  \feat{Scale} = \meta{number} \\
  \feat{Scale} = \opt{MatchLowercase} \\
- \feat{Scale} = \opt{MatchUppercase}
+ \feat{Scale} = \opt{MatchUppercase} \\
+ \feat{Scale} = \opt{MatchAveragecase}
 }
 
 In its explicit form, \feat{Scale} takes a single
@@ -377,10 +378,11 @@ numeric argument for linearly scaling the font, as demonstrated
 in \exref{fontload}.
 
 As well as a numerical argument, the \feat{Scale} feature
-also accepts options \opt{MatchLowercase}
-and \opt{MatchUppercase}, which will scale the font being selected to match
-the current default roman font to either the height of the lowercase or
-uppercase letters, respectively; these features are shown in \exref{scale}.
+also accepts options \opt{MatchLowercase}, \opt{MatchUppercase},
+and \opt{MatchAveragecase}, which will scale the font being selected to match
+the current default roman font to either the height of the lowercase,
+the height of the uppercase letters, or the average of the two,
+respectively; these features are shown in \exref{scale}.
 The amount of scaling used in each instance is reported in the \texttt{.log} file.
 
 \begin{Xexample}{scale}{Automatically calculated scale values.}
@@ -388,7 +390,9 @@ The amount of scaling used in each instance is reported in the \texttt{.log} fil
   \newfontfamily\lc[Scale=MatchLowercase]{Verdana}
    The perfect match {\lc is hard to find.}\\
   \newfontfamily\uc[Scale=MatchUppercase]{Arial}
-   L O G O \uc F O N T
+   L O G O {\uc F O N T}\\
+  \newfontfamily\ac[Scale=MatchAveragecase]{Fira Math}
+   Lower {\ac and UPPER} CASE
 \end{Xexample}
 
 Additional calls to the \feat{Scale} feature overwrite the settings of the former.
@@ -400,7 +404,8 @@ necessary. For example:
   [ Scale = 1.1 , ScaleAgain = 1.2 ] % -> scale of 1.32
 \end{Verbatim}
 
-Note that when |Scale=MatchLowercase| is used with |\setmainfont|, the new `main'
+Note that when |Scale=MatchLowercase|, |Scale=MatchUppercase|, or |Scale=MatchAverageCase|
+is used with |\setmainfont|, the new `main'
 font of the document will be scaled to match the old default.
 If you wish to automatically scale all fonts except have the main font use `natural'
 scaling, you may write

--- a/testfiles/feat-scale-match.luatex.tlg
+++ b/testfiles/feat-scale-match.luatex.tlg
@@ -31,5 +31,14 @@ TU/texgyrecursor-regular.otf(2)/m/n:
   [texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt; at 10.79132pt
 font dimen 5: 4.49998pt
 font dimen 8: 6.07552pt
+MATCH AVERAGECASE
+TU/texgyreheros-regular.otf(3)/m/n:
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt; at 8.83438pt
+font dimen 5: 4.62921pt
+font dimen 8: 6.44026pt
+TU/texgyrecursor-regular.otf(3)/m/n:
+  [texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt; at 11.27487pt
+font dimen 5: 4.70161pt
+font dimen 8: 6.34775pt
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/feat-scale-match.lvt
+++ b/testfiles/feat-scale-match.lvt
@@ -22,4 +22,8 @@
 \fontspec[Scale=MatchLowercase]{texgyreheros-regular.otf}  \X
 \fontspec[Scale=MatchLowercase]{texgyrecursor-regular.otf} \X
 
+\MSG{MATCH AVERAGECASE}
+\fontspec[Scale=MatchAveragecase]{texgyreheros-regular.otf}  \X
+\fontspec[Scale=MatchAveragecase]{texgyrecursor-regular.otf} \X
+
 \end{document}

--- a/testfiles/feat-scale-match.tlg
+++ b/testfiles/feat-scale-match.tlg
@@ -31,5 +31,14 @@ TU/texgyrecursor-regular.otf(2)/m/n:
   "[texgyrecursor-regular.otf]/OT:script=latn;language=dflt;" at 10.79132pt
 font dimen 5: 4.49998pt
 font dimen 8: 6.07552pt
+MATCH AVERAGECASE
+TU/texgyreheros-regular.otf(3)/m/n:
+  "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;" at 8.83438pt
+font dimen 5: 4.62921pt
+font dimen 8: 6.44026pt
+TU/texgyrecursor-regular.otf(3)/m/n:
+  "[texgyrecursor-regular.otf]/OT:script=latn;language=dflt;" at 11.27487pt
+font dimen 5: 4.70161pt
+font dimen 8: 6.34775pt
 ***************
 Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY**

## Description
I have added a `Scale=MatchAveragecase` option to complement `Scale=MatchLowercase` and `Scale=MatchUppercase`, it simply sets the Scale to the average of what `MatchLowercase` and `MatchUppercase` would do. This is usefull when you can't make up your mind whether to use `MatchLowercase` or `MatchUppercase`, or when neither looks good, as in the example below (where in my opinion, the `MatchAveragecase` version looks the best)

## Todos
- [x] Tests added to cover new/fixed functionality
- [x] Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\setmainfont{TeXGyreSchola}
\newfontfamily\lc[Scale=MatchLowercase]{Fira Math}
\newfontfamily\uc[Scale=MatchUppercase]{Fira Math}
\newfontfamily\ac[Scale=MatchAveragecase]{Fira Math}
\begin{document}
\noindent
Lower {\lc and UPPER} CASE\\
Lower {\uc and UPPER} CASE\\
Lower {\ac and UPPER} CASE
\end{document}
```

