### PR TITLE
Use keyval for package options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change history
 ==============
-
+## [Unreleased]
+  * switched options to LaTeX keyval handler
+  * added option verbose to undo silent/quiet
+  * euenc/tuenc options are obsolete
+  * TU is the only encoding 
 ## v2.8a (2022/01/15)
 
   * Add `SwashFont` and `BoldSwashFont` features to support LaTeX's now-builtin `\textsw`

--- a/fontspec-code-load.dtx
+++ b/fontspec-code-load.dtx
@@ -21,7 +21,7 @@
   {
     \RequirePackage{luaotfload}
     \lua_now:e{require("fontspec")}
-    \RequirePackageWithOptions{fontspec-luatex}
+    \RequirePackage{fontspec-luatex}
     \endinput
   }
 %    \end{macrocode}
@@ -30,7 +30,7 @@
 %    \begin{macrocode}
 \sys_if_engine_xetex:T
   {
-    \RequirePackageWithOptions{fontspec-xetex}
+    \RequirePackage{fontspec-xetex}
     \endinput
   }
 %    \end{macrocode}

--- a/fontspec-code-msg.dtx
+++ b/fontspec-code-msg.dtx
@@ -189,14 +189,21 @@
   Input mapping not supported in LuaTeX.\\
   Use "Ligatures=TeX" instead of "Mapping=tex-text".
  }
-\@@_msg_new:nn {cm-default-obsolete}
+%    \end{macrocode}
+% message for package options must be loaded earlier
+%    \begin{macrocode}
+%</fontspec>
+%<*options>
+\msg_new:nnn {fontspec} {cm-default-obsolete}
  {
-  The "cm-default" package option is obsolete.
+  The~"cm-default"~package~option~is~obsolete.
  }
-\@@_msg_new:nn {enc-obsolete}
+\msg_new:nnn {fontspec} {enc-obsolete}
  {
-  The "#1" package option is obsolete. TU is the default encoding.
- } 
+  The~"#1"~package~option~is~obsolete.~TU~is~the~default~encoding.
+ }
+%</options>
+%<*fontspec> 
 \@@_msg_new:nn {font-index-needs-ttc}
  {
   The "FontIndex" feature is only supported by TTC (TrueType Collection) fonts.\\

--- a/fontspec-code-msg.dtx
+++ b/fontspec-code-msg.dtx
@@ -193,6 +193,10 @@
  {
   The "cm-default" package option is obsolete.
  }
+\@@_msg_new:nn {enc-obsolete}
+ {
+  The "#1" package option is obsolete. TU is the default encoding.
+ } 
 \@@_msg_new:nn {font-index-needs-ttc}
  {
   The "FontIndex" feature is only supported by TTC (TrueType Collection) fonts.\\

--- a/fontspec-code-opening.dtx
+++ b/fontspec-code-opening.dtx
@@ -4,75 +4,74 @@
 %
 % \iffalse
 %    \begin{macrocode}
-%<*fontspec>
+%<*options>
 %    \end{macrocode}
 % \fi
 %
 % \subsection{Package options}
 %
 %    \begin{macrocode}
-\DeclareOption{cm-default}
+\DeclareKeys 
   {
-    \@@_warning:n {cm-default-obsolete}
-  }
+    cm-default  .code:n = { \@@_warning:n {cm-default-obsolete} }    
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareOption {math}     { \bool_gset_true:N  \g_@@_math_bool  }
-\DeclareOption {no-math}  { \bool_gset_false:N \g_@@_math_bool  }
-\DeclareOption {config}   { \bool_gset_true:N  \g_@@_cfg_bool   }
-\DeclareOption {no-config}{ \bool_gset_false:N \g_@@_cfg_bool   }
-\DeclareOption {euenc}    { \bool_gset_true:N  \g_@@_euenc_bool }
-\DeclareOption {tuenc}    { \bool_gset_false:N \g_@@_euenc_bool }
+    ,math    .bool_gset:N = \g_@@_math_bool
+    ,math    .usage:n     =  preamble
+    ,no-math .bool_gset_inverse:N = \g_@@_math_bool
+    ,no-math .usage:n             =  preamble
+    ,config  .bool_gset:N = \g_@@_cfg_bool
+    ,config  .usage:n     = load
+    ,no-config  .bool_gset_inverse:N = \g_@@_cfg_bool
+    ,no-config  .usage:n             = load
+    ,euenc  .code:n = { \@@_warning:nx {enc-obsolete}{euenc} }    
+    ,tuenc  .code:n = { \@@_warning:nx {enc-obsolete}{tuenc} }    
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\DeclareOption {quiet}
-  {
-    \msg_redirect_module:nnn { fontspec } { warning } { info }
-    \msg_redirect_module:nnn { fontspec } { info } { none }
-  }
-\DeclareOption{silent}
-  {
-    \msg_redirect_module:nnn { fontspec } { warning } { none }
-    \msg_redirect_module:nnn { fontspec } { info } { none }
-  }
+    ,quiet .code:n = 
+      {
+        \msg_redirect_module:nnn { fontspec } { warning } { info }
+        \msg_redirect_module:nnn { fontspec } { info } { none }
+      }
+    ,silent .code:n = 
+      {
+        \msg_redirect_module:nnn { fontspec } { warning } { none }
+        \msg_redirect_module:nnn { fontspec } { info } { none }
+      }
+    ,verbose .code:n = 
+      {
+        \msg_redirect_module:nnn { fontspec } { warning } { warning }
+        \msg_redirect_module:nnn { fontspec } { info } { info }      
+      }  
+  }        
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\ExecuteOptions{config,math,tuenc}
-\ProcessOptions*
+\SetKeys{config,math}
+\ProcessKeyOptions
 %    \end{macrocode}
 %
-%
+% \iffalse
+%    \begin{macrocode}
+%</options>
+%<*fontspec>
+%    \end{macrocode}
+% \fi
 %
 %
 % \subsection{Encodings}
 %
-% Soon to be the default, with a just-in-case check:
+% Now the default, with a just-in-case check:
 %    \begin{macrocode}
-\bool_if:NF \g_@@_euenc_bool
+\cs_if_exist:cF {T@TU}
   {
-    \file_if_exist:nTF {tuenc.def}
-      {
-        \cs_if_exist:cF {T@TU}
-          {
-            \@@_warning:n {tu-clash}
-            \DeclareFontEncoding{TU}{}{}
-            \DeclareFontSubstitution{TU}{lmr}{m}{n}
-          }
-      }
-      {
-        \@@_warning:n {tu-missing}
-        \bool_gset_true:N \g_@@_euenc_bool
-      }
+    \@@_warning:n {tu-clash}
+    \DeclareFontEncoding{TU}{}{}
+    \DeclareFontSubstitution{TU}{lmr}{m}{n}
   }
-\bool_if:NTF \g_@@_euenc_bool
-  {
-%<XE>    \tl_gset:Nn \g_fontspec_encoding_tl {EU1}
-%<LU>    \tl_gset:Nn \g_fontspec_encoding_tl {EU2}
-  }
-  { \tl_gset:Nn \g_fontspec_encoding_tl { TU } }
+\tl_gset:Nn \g_fontspec_encoding_tl { TU }  
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -99,16 +98,6 @@
 % That latin encoding definition is repeated to suppress font warnings.
 % Something to do with \cmd\select@language\ ending up in the \texttt{.aux}
 % file which is read at the beginning of the document.
-%
-%    \begin{macrocode}
-\bool_if:NT \g_@@_euenc_bool
-  {
-%<LU>    \cs_set_eq:NN \fontspec_tmp: \XeTeXpicfile
-%<LU>    \cs_set:Npn \XeTeXpicfile {}
-    \RequirePackage{xunicode}
-%<LU>    \cs_set_eq:NN \XeTeXpicfile \fontspec_tmp:
-  }
-%    \end{macrocode}
 %
 %
 % \subsection{Generic functions}

--- a/fontspec-code-opening.dtx
+++ b/fontspec-code-opening.dtx
@@ -26,7 +26,7 @@
     ,no-config  .bool_gset_inverse:N = \g_@@_cfg_bool
     ,no-config  .usage:n             = load
     ,euenc  .code:n = { \msg_warning:nnn   {fontspec} {enc-obsolete}{euenc} }    
-    ,tuenc  .code:n = { \msg_warning:nnb   {fontspec} {enc-obsolete}{tuenc} }    
+    ,tuenc  .code:n = { \msg_warning:nnn   {fontspec} {enc-obsolete}{tuenc} }    
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/fontspec-code-opening.dtx
+++ b/fontspec-code-opening.dtx
@@ -13,7 +13,7 @@
 %    \begin{macrocode}
 \DeclareKeys 
   {
-    cm-default  .code:n = { \@@_warning:n {cm-default-obsolete} }    
+    cm-default  .code:n = { \msg_warning:nn   {fontspec} {cm-default-obsolete} }    
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -25,8 +25,8 @@
     ,config  .usage:n     = load
     ,no-config  .bool_gset_inverse:N = \g_@@_cfg_bool
     ,no-config  .usage:n             = load
-    ,euenc  .code:n = { \@@_warning:nx {enc-obsolete}{euenc} }    
-    ,tuenc  .code:n = { \@@_warning:nx {enc-obsolete}{tuenc} }    
+    ,euenc  .code:n = { \msg_warning:nnn   {fontspec} {enc-obsolete}{euenc} }    
+    ,tuenc  .code:n = { \msg_warning:nnb   {fontspec} {enc-obsolete}{tuenc} }    
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/fontspec-code-vars.dtx
+++ b/fontspec-code-vars.dtx
@@ -4,6 +4,7 @@
 %
 % \iffalse
 %    \begin{macrocode}
+%<@@=fontspec>
 %<*fontspec>
 %    \end{macrocode}
 % \fi
@@ -50,9 +51,12 @@
 %    \end{macrocode}
 % For package options:
 %    \begin{macrocode}
+%</fontspec>
+%<*options>
 \bool_new:N \g_@@_cfg_bool
 \bool_new:N \g_@@_math_bool
-\bool_new:N \g_@@_euenc_bool
+%</options>
+%<*fontspec>
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/fontspec-doc-intro.tex
+++ b/fontspec-doc-intro.tex
@@ -75,17 +75,19 @@ For basic use, no package options are required:
   \usepackage{fontspec}
 \end{Verbatim}
 Package options will be introduced below; some preliminary details are discussed first.
-
+Package options are setup with the in-built \LaTeX{} keyval options handler. This means
+that the package can be loaded more than once with different options without triggering
+an option clash error. The \texttt{config} and \texttt{no-config} option must be used in
+the first loading and are ignored later.
 
 \subsection{Font encodings}
 
-The (default) \texttt{tuenc} package option switches the \textsc{nfss} font encoding to \texttt{TU}.
+The package switches the \textsc{nfss} font encoding to \texttt{TU}.
 \texttt{TU} is a new Unicode font encoding, intended for both \XeTeX\ and \LuaTeX\ engines, and automatically contains support for symbols covered by \LaTeX's traditional \texttt{T1} and \texttt{TS1} font encodings (for example, |\%|, |\textbullet|, |\"u|, and so on).
 Some additional features are provided by \pkg{fontspec} to customise some encoding details; see Part~\vref{part:enc} for further details.
 
-Pre-2017 behaviour can be achieved with the \texttt{euenc} package option.
-This selects the \texttt{EU1} or \texttt{EU2} encoding (\XeTeX/\LuaTeX, resp.) and loads the \pkg{xunicode} package for symbol support.
-Package authors and users who have referred explicitly to the encoding names \texttt{EU1} or \texttt{EU2} should update their code or documents.
+Pre-2017 behaviour is now obsolete. The \texttt{euenc} and \texttt{tuenc} package options are
+ignored. Package authors and users who have referred explicitly to the encoding names \texttt{EU1} or \texttt{EU2} should update their code or documents.
 (See internal variable names described in \vref{sec:api} for how to do this properly.)
 
 
@@ -108,7 +110,7 @@ A |fontspec.cfg| file is distributed with \pkg{fontspec} with a small number of 
 To customise \pkg{fontspec} to your liking, use the standard |.cfg| file as a starting point or write your own from scratch, then either place it in the same folder as the main document for isolated cases, or in a location
 that \XeTeX\ or \LuaTeX\ searches by default; \eg\ in Mac\TeX: \path{~/Library/texmf/tex/latex/}.
 
-The package option |no-config| will suppress the loading of the |fontspec.cfg| file under all circumstances.
+The package option |no-config| will suppress the loading of the |fontspec.cfg| file under all circumstances. Both options must be used the first time \pkg{fontspec} is loaded and are ignored in later calls.
 
 
 \subsection{Warnings}
@@ -121,7 +123,7 @@ transcript (\texttt{.log}) file instead.
 Use the |silent| package option to completely suppress these warnings if you
 don't even want the |.log| file cluttered up.
 
-
+Both options can also be used with \cs{Setkeys} in the document. Use the |verbose| option to get activate the warnings again.
 
 \section{Interaction with \LaTeXe\ and other packages}
 

--- a/fontspec.ins
+++ b/fontspec.ins
@@ -33,6 +33,7 @@ the conditions of the LaTeX Project Public License, version 1.3c or higher
 \generate{\file{fontspec.sty}{
   \from{fontspec.dtx}{fontspec,load\FSDEBUG}
   \from{fontspec-code-vars.dtx}{options}
+  \from{fontspec-code-msg.dtx}{options}
   \from{fontspec-code-opening.dtx}{options}
   \from{fontspec-code-load.dtx}{fontspec,load\FSDEBUG}
 }}

--- a/fontspec.ins
+++ b/fontspec.ins
@@ -32,6 +32,8 @@ the conditions of the LaTeX Project Public License, version 1.3c or higher
 
 \generate{\file{fontspec.sty}{
   \from{fontspec.dtx}{fontspec,load\FSDEBUG}
+  \from{fontspec-code-vars.dtx}{options}
+  \from{fontspec-code-opening.dtx}{options}
   \from{fontspec-code-load.dtx}{fontspec,load\FSDEBUG}
 }}
 

--- a/testfiles/00-pkg-load-twice.luatex.tlg
+++ b/testfiles/00-pkg-load-twice.luatex.tlg
@@ -1,0 +1,16 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [1]
+\hbox(0.0+0.0)x0.0, glue set - 1.0, direction TLT
+.\TU/lmr/m/n/10 h
+.\TU/lmr/m/n/10 e
+.\TU/lmr/m/n/10 l
+.\TU/lmr/m/n/10 l
+.\TU/lmr/m/n/10 o
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 a
+.\mathoff
+.\glue(\spaceskip) 3.33 plus 1.665 minus 1.11
+***************
+Compilation 1 of test file completed with exit status 0

--- a/testfiles/00-pkg-load-twice.lvt
+++ b/testfiles/00-pkg-load-twice.lvt
@@ -1,0 +1,6 @@
+\input{fontspec-testsetup}
+\usepackage{fontspec}
+\usepackage[no-math]{fontspec}
+\begin{document}
+\SHIPOUT{hello $\mathrm{a}$ } 
+\end{document}

--- a/testfiles/00-pkg-load-twice.tlg
+++ b/testfiles/00-pkg-load-twice.tlg
@@ -1,0 +1,12 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [1]
+\hbox(0.0+0.0)x0.0, glue set - 1.0
+.\TU/lmr/m/n/10 hello
+.\glue 3.33 plus 1.665 minus 1.11
+.\mathon
+.\OT1/cmr/m/n/10 a
+.\mathoff
+.\glue 3.33 plus 1.665 minus 1.11
+***************
+Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY**

## Description
* changes the package option to the new keyval-handler to avoid option clash errors.
* removed the euenc code
* made the euenc and tuenc option obsolete.

## Todos
- [x] Tests added to cover new/fixed functionality
- [x] Documentation if necessary
- [x] Code follows expl3 style guidelines

## Minimal example demonstrating the new/fixed functionality
```
\documentclass{article}
\usepackage{fontspec}
\usepackage[no-math]{fontspec}
\begin{document}
hello $\mathrm{a}$ 
\end{document}
```

