### PR TITLE
l3color named color support and spotcolors in LuaLaTeX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Change history
   * Support variable fonts under LuaLaTeX.
   * Skip scanning for filenames when loading fonts by name on LuaLaTeX.
   * Allow restricting filename lookup to kpathsea lookups using `KpseOnly`.
+  * added support for named colors from l3color 
+  * support with lualatex spotcolors and cmyk colors in the pdf. 
 
 
 ## v2.8a (2022/01/15)

--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -371,7 +371,8 @@
 
     \str_if_eq:eeF { \l_@@_hexcol_tl \l_@@_opacity_tl }
                      { \c_@@_hexcol_tl \c_@@_opacity_tl }
-      { \@@_update_featstr:n { color = \l_@@_hexcol_tl\l_@@_opacity_tl } }
+%<XE>       { \@@_update_featstr:n { color = \l_@@_hexcol_tl\l_@@_opacity_tl } }
+%<LU>       { \@@_update_featstr:n { color = {\l_@@_hexcol_tl\l_@@_opacity_tl} } }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -701,6 +701,7 @@
 %    \begin{macrocode}
 \@@_keys_define_code:nnn {fontspec} {Color}
   {
+%<*XE>
     \cs_if_exist:cTF { \token_to_str:N \color@ #1 }
       {
         \convertcolorspec{named}{#1}{HTML}\l_@@_hexcol_tl
@@ -717,6 +718,10 @@
               }
           }
       }
+%</XE>
+%<*LU>
+    \tl_set:Nn \l_@@_hexcol_tl {#1}
+%</LU>
   }
 %    \end{macrocode}
 %
@@ -745,6 +750,7 @@
       }
     \tl_set:Nx \l_@@_opacity_tl
       {
+%<LU>      ,
         \int_compare:nT { \l_@@_tmp_int <= "F } {0} % zero pad
         \int_to_hex:n { \l_@@_tmp_int }
       }

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -697,30 +697,51 @@
 %    \end{macrocode}
 %
 % \paragraph{Color}
-% Hooks into pkg{xcolor}, which names its colours \texttt{\char`\\color@<name>}.
+% Test first if the color is a named l3color, then if it is a color from
+% \pkg{xcolor}, which names its colours \texttt{\char`\\color@<name>}.
+% If this fails the argument is assumed to be a hex color.
+%
 %    \begin{macrocode}
 \@@_keys_define_code:nnn {fontspec} {Color}
   {
 %<*XE>
-    \cs_if_exist:cTF { \token_to_str:N \color@ #1 }
+    \color_if_exist:nTF {#1}
       {
-        \convertcolorspec{named}{#1}{HTML}\l_@@_hexcol_tl
+        \color_export:nnN {#1} {HTML}\l_@@_hexcol_tl
       }
       {
-        \int_compare:nTF { \tl_count:n {#1} == 6 }
-          { \tl_set:Nn \l_@@_hexcol_tl {#1} }
+        \cs_if_exist:cTF { \token_to_str:N \color@ #1 }        
           {
-            \int_compare:nTF { \tl_count:n {#1} == 8 }
-              { \fontspec_parse_colour:viii #1 }
+            \convertcolorspec{named}{#1}{HTML}\l_@@_hexcol_tl
+          }
+          {
+            \int_compare:nTF { \tl_count:n {#1} == 6 }
+              { \tl_set:Nn \l_@@_hexcol_tl {#1} }
               {
-                \bool_if:NF \l_@@_firsttime_bool
-                  { \@@_warning:nx {bad-colour} {#1} }
+                \int_compare:nTF { \tl_count:n {#1} == 8 }
+                  { \fontspec_parse_colour:viii #1 }
+                  {
+                    \bool_if:NF \l_@@_firsttime_bool
+                      { \@@_warning:nx {bad-colour} {#1} }
+                  }
               }
           }
       }
 %</XE>
 %<*LU>
-    \tl_set:Nn \l_@@_hexcol_tl {#1}
+    \color_if_exist:nTF {#1}
+      {
+        \tl_set:Nn \l_@@_hexcol_tl {#1}
+      }
+      {
+        \cs_if_exist:cTF { \token_to_str:N \color@ #1 }        
+          {
+            \convertcolorspec{named}{#1}{HTML}\l_@@_hexcol_tl
+          }
+          {
+            \tl_set:Nn \l_@@_hexcol_tl {#1}
+          }
+      }      
 %</LU>
   }
 %    \end{macrocode}

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -739,7 +739,16 @@
             \convertcolorspec{named}{#1}{HTML}\l_@@_hexcol_tl
           }
           {
-            \tl_set:Nn \l_@@_hexcol_tl {#1}
+            \int_compare:nTF { \tl_count:n {#1} == 6 }
+              { \tl_set:Nn \l_@@_hexcol_tl {#1} }
+              {
+                \int_compare:nTF { \tl_count:n {#1} == 8 }
+                  { \fontspec_parse_colour:viii #1 }
+                  {
+                    \bool_if:NF \l_@@_firsttime_bool
+                      { \@@_warning:nx {bad-colour} {#1} }
+                  }
+              }
           }
       }      
 %</LU>

--- a/fontspec-code-vars.dtx
+++ b/fontspec-code-vars.dtx
@@ -299,7 +299,8 @@
 %
 %    \begin{macrocode}
 \tl_const:Nn \c_@@_hexcol_tl {000000}
-\tl_const:Nn \c_@@_opacity_tl {FF~}
+%<XE> \tl_const:Nn \c_@@_opacity_tl {FF~}
+%<LU> \tl_const:Nn \c_@@_opacity_tl {}
 \tl_const:Nn \c_@@_postadjust_tl { \l_@@_wordspace_adjust_tl \l_@@_punctspace_adjust_tl }
 %    \end{macrocode}
 %

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -330,7 +330,7 @@ Notably, this mechanism is different to that of the \pkg{color}/\pkg{xcolor}/\pk
 (For example, if you set the colour in a \verb|\setmainfont| command, \verb|\color{...}| and related commands, including hyperlink colouring, will no longer have any effect on text in this font.)
 Therefore, \pkg{fontspec}'s colour commands are best used to set explicit colours in specific situations, and the \pkg{xcolor} package is recommended for more general colour functionality.
 
-The colour is defined as a triplet of two-digit Hex RGB
+The colour can be defined as a triplet of two-digit Hex RGB
 values, with optionally another value for the transparency (where
 |00| is completely transparent and |FF| is opaque.)
 \begin{Lexample}{color}{Selecting colour with transparency.}
@@ -341,8 +341,6 @@ values, with optionally another value for the transparency (where
   {\addfontfeature{Color=DDBB2299}P}\kern-0.5ex
   {\addfontfeature{Color=00BB3399}R}
 \end{Lexample}
-Transparency is supported by \LuaLaTeX; \XeLaTeX\ with the \texttt{xdvipdfmx} driver
-does not support this feature.
 
 If you load the \pkg{xcolor} package, you may use any named colour instead
 of writing the colours in hexadecimal.

--- a/fontspec-doc-featset.tex
+++ b/fontspec-doc-featset.tex
@@ -351,16 +351,60 @@ of writing the colours in hexadecimal.
  \definecolor{Foo}{rgb}{0.3,0.4,0.5}
  \fontspec[Color=Foo]{Verdana} ...
 \end{Verbatim}
-The \pkg{color} package is \emph{not} supported; use \pkg{xcolor} instead.
 
-You may specify the transparency with a named colour using the \feat{Opacity}
-feature which takes an decimal from zero to one corresponding to
-transparent to opaque respectively:
+You may also use named colours defined with the color commands of the L3 
+programming layer:
+\begin{Verbatim}
+ \ExplSyntaxOn
+ \color_set:nnn{Foo}{rgb}{0.3,0.4,0.5}
+\ExplSyntaxOff
+ ...
+ \fontspec[Color=Foo]{Verdana} ...
+\end{Verbatim}
+
+Color expressions (\verb+red!50!blue+) are not supported. The \pkg{color} 
+package is \emph{not} supported neither. 
+
+The code will at first test for color names of the L3 layer, then for xcolor 
+names and at last try to use the argument as a hexadecimal value.
+
+You may specify the transparency with a named colour using the \feat{Opacity} 
+feature which takes an decimal from zero to one corresponding to transparent 
+to opaque respectively: 
 \begin{Verbatim}
  \fontspec[Color=red,Opacity=0.7]{Verdana} ...
 \end{Verbatim}
 It is still possible to specify a colour in six-char hexadecimal form
 while defining opacity in this way, if you like.
+
+\subsubsection{Color models}
+
+With \XeTeX\ color are always written in the rgb color model into the PDF. 
+When using \LuaTeX, colors with the commands of the L3 layer can be written 
+as rgb or cmyk or as spot color depending on their definition and of the 
+value of the variable \verb+\l_color_fixed_model_tl+. 
+ 
+\subsubsection{Spot colors} 
+With \LuaTeX\ it is possible to use spot colors. This requires the use of the 
+PDF management:
+\begin{Verbatim}
+\DocumentMetadata{}
+\documentclass{article}
+\usepackage{fontspec}
+\ExplSyntaxOn
+ \color_model_new:nnn { sepblue } { Separation }
+    {
+      name = PANTONE~3005~U ,
+      alternative-model = cmyk ,
+      alternative-values = {1, 0.56, 0,0},
+    }
+ \color_set:nnn{spotblue}{sepblue}{1}
+\ExplSyntaxOff
+...
+\fontspec[Color=spotblue]{texgyreheros}
+\end{Verbatim}
+
+ 
 
 \subsection{Scale}
 

--- a/testfiles/aff-group.luatex.tlg
+++ b/testfiles/aff-group.luatex.tlg
@@ -6,13 +6,13 @@ TU/texgyretermes-regular.otf(0)/m/n:
   [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 Adding a colour:
 TU/texgyretermes-regular.otf(1)/m/n:
-  "[texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA00AAFF ;"
+  [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA00AA};
 Back to normalfont:
 TU/texgyretermes-regular.otf(0)/m/n:
   [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 Open group and add a different colour:
 TU/texgyretermes-regular.otf(2)/m/n:
-  "[texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AAAAFF ;"
+  [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AAAA};
 End the group:
 TU/texgyretermes-regular.otf(0)/m/n:
   [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
@@ -21,9 +21,9 @@ The following demonstrates strange behaviour to be wary of.
 TU/texgyrepagella-regular.otf(0)/m/n:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella-regular.otf(0)/m/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA00AAFF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA00AA};
 TU/texgyrepagella-regular.otf(0)/m/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA00AAFF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA00AA};
 ============================================================
 And check NFSSFamily use inside a group.
 Reload another font:
@@ -31,7 +31,7 @@ TU/texgyreheros-regular.otf(0)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 Open group and add a different colour, without changing family:
 TU/texgyreheros-regular.otf(0)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AAAAFF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AAAA};
 End the group:
 TU/texgyreheros-regular.otf(0)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;

--- a/testfiles/aff-italic-only.luatex.tlg
+++ b/testfiles/aff-italic-only.luatex.tlg
@@ -6,9 +6,9 @@ TU/texgyrepagella(0)/m/n:
 TU/texgyrepagella(0)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella(0)/m/it:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA0000};
 TU/texgyrepagella(0)/m/scit:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={AA0000};
 TU/texgyrepagella(0)/b/n:
   [texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella(0)/b/sc:
@@ -23,9 +23,9 @@ TU/texgyrepagella(1)/m/n:
 TU/texgyrepagella(1)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;
 TU/texgyrepagella(1)/m/it:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;color={AA0000};
 TU/texgyrepagella(1)/m/scit:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;color={AA0000};
 TU/texgyrepagella(1)/b/n:
   [texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;
 TU/texgyrepagella(1)/b/sc:
@@ -40,9 +40,9 @@ TU/texgyrepagella(2)/m/n:
 TU/texgyrepagella(2)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella(2)/m/it:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;color={AA0000};
 TU/texgyrepagella(2)/m/scit:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;color={AA0000};
 TU/texgyrepagella(2)/b/n:
   [texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella(2)/b/sc:

--- a/testfiles/aff-sc-repeated.luatex.tlg
+++ b/testfiles/aff-sc-repeated.luatex.tlg
@@ -6,9 +6,9 @@ TU/texgyrepagella(0)/m/n:
 TU/texgyrepagella(0)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella(0)/m/it:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA0000};
 TU/texgyrepagella(0)/m/scit:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={AA0000};
 TU/texgyrepagella(0)/b/n:
   [texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella(0)/b/sc:
@@ -23,9 +23,9 @@ TU/texgyrepagella(1)/m/n:
 TU/texgyrepagella(1)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;+onum;
 TU/texgyrepagella(1)/m/it:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA0000};
 TU/texgyrepagella(1)/m/scit:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;+pnum;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;+pnum;color={AA0000};
 TU/texgyrepagella(1)/b/n:
   [texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella(1)/b/sc:

--- a/testfiles/colour-basic.luatex.tlg
+++ b/testfiles/colour-basic.luatex.tlg
@@ -4,12 +4,12 @@ Loading xcolor...
 ...done
 Loading a font with hex colour:
 TU/texgyreheros-regular.otf(0)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=5500FFFF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={5500FF};
 Loading a font by name (xcolor):
 TU/texgyreheros-regular.otf(1)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={red};
 Defining a new xcolor colour and using it:
 TU/texgyreheros-regular.otf(2)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=4D6680FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={Foo};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/colour-basic.luatex.tlg
+++ b/testfiles/colour-basic.luatex.tlg
@@ -5,11 +5,14 @@ Loading xcolor...
 Loading a font with hex colour:
 TU/texgyreheros-regular.otf(0)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={5500FF};
-Loading a font by name (xcolor):
+Loading a font by name (l3color+xcolor):
 TU/texgyreheros-regular.otf(1)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={red};
 Defining a new xcolor colour and using it:
 TU/texgyreheros-regular.otf(2)/m/n:
-  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={Foo};
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={4D6680};
+Defining a new l3color colour and using it:
+TU/texgyreheros-regular.otf(3)/m/n:
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={Bar};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/colour-basic.lvt
+++ b/testfiles/colour-basic.lvt
@@ -9,11 +9,17 @@
 \MSG{Loading a font with hex colour:}
 {\fontspec[Color=5500FF]{texgyreheros-regular.otf}\CURRNFSS}
 
-\MSG{Loading a font by name (xcolor):}
+\MSG{Loading a font by name (l3color+xcolor):}
 {\fontspec[Color=red]{texgyreheros-regular.otf}\CURRNFSS}
 
 \MSG{Defining a new xcolor colour and using it:}
 \definecolor{Foo}{rgb}{0.3,0.4,0.5}
 {\fontspec[Color=Foo]{texgyreheros-regular.otf}\CURRNFSS}
+
+\MSG{Defining a new l3color colour and using it:}
+\ExplSyntaxOn
+\color_set:nnn{Bar}{rgb}{0.5,0.4,0.3}
+\ExplSyntaxOff
+{\fontspec[Color=Bar]{texgyreheros-regular.otf}\CURRNFSS}
 
 \end{document}

--- a/testfiles/colour-basic.tlg
+++ b/testfiles/colour-basic.tlg
@@ -5,11 +5,14 @@ Loading xcolor...
 Loading a font with hex colour:
 TU/texgyreheros-regular.otf(0)/m/n:
   "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=5500FFFF ;" at 10.0pt
-Loading a font by name (xcolor):
+Loading a font by name (l3color+xcolor):
 TU/texgyreheros-regular.otf(1)/m/n:
   "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=FF0000FF ;" at 10.0pt
 Defining a new xcolor colour and using it:
 TU/texgyreheros-regular.otf(2)/m/n:
   "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=4D6680FF ;" at 10.0pt
+Defining a new l3color colour and using it:
+TU/texgyreheros-regular.otf(3)/m/n:
+  "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=80664CFF ;" at 10.0pt
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/colour-model.luatex.tpf
+++ b/testfiles/colour-model.luatex.tpf
@@ -1,0 +1,272 @@
+%PDF-1.5
+%Ã’¡‘≈ÿ–ƒ∆
+3 0 obj
+<< /Length 904 >>        
+stream
+0 1 0 rg
+BT
+/F20 9.96264 Tf
+1 0 0 1 29.117 145.943 Tm [<0069>95<00330063>5<006A>]TJ
+0 g 0 G
+1.0 0.0 0.0 rg 1.0 0.0 0.0 RG
+/F20 9.96264 Tf
+1 0 0 1 29.117 133.988 Tm [<0069>95<00330063>5<006A>]TJ
+0 g 0 G
+1.0 0.0 0.5 0.0 k 1.0 0.0 0.5 0.0 K
+/F20 9.96264 Tf
+1 0 0 1 29.117 122.033 Tm [<0069>95<00330063>5<006A>]TJ
+0 g 0 G
+0 1 0 rg
+/F26 9.96264 Tf
+1 0 0 1 29.117 110.077 Tm [<0069>85<00330063>15<006A>]TJ
+0 g 0 G
+1.0 0.0 0.0 rg 1.0 0.0 0.0 RG
+/F26 9.96264 Tf
+1 0 0 1 29.117 98.122 Tm [<0069>85<00330063>15<006A>]TJ
+0 g 0 G
+0 1 0.5 rg 0 1 0.5 RG
+/F26 9.96264 Tf
+1 0 0 1 29.117 86.167 Tm [<0069>85<00330063>15<006A>]TJ
+0 g 0 G
+0 1 0 rg
+/F32 9.96264 Tf
+1 0 0 1 29.117 74.212 Tm [<006900330063006A>]TJ
+0 g 0 G
+0 1 1 0 k 0 1 1 0 K
+/F32 9.96264 Tf
+1 0 0 1 29.117 62.257 Tm [<006900330063006A>]TJ
+0 g 0 G
+1.0 0.0 0.5 0.0 k 1.0 0.0 0.5 0.0 K
+/F32 9.96264 Tf
+1 0 0 1 29.117 50.302 Tm [<006900330063006A>]TJ
+0 g 0 G
+ET
+endstream
+endobj
+2 0 obj
+<< /Type /Page /Contents 3 0 R /Resources 1 0 R /MediaBox [ 0 0 255.118 170.079 ] /Parent 7 0 R >>
+endobj
+1 0 obj
+<< /Font << /F20 4 0 R /F26 5 0 R /F32 6 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+8 0 obj
+[ 51 [ 600 ] 99 [ 600 ] 105 [ 600 600 ] ]
+endobj
+10 0 obj
+<< /Length 14 >>         
+[BINARY STREAM]
+endobj
+11 0 obj
+<< /Subtype /CIDFontType0C /Length 974 >>        
+[BINARY STREAM]
+endobj
+9 0 obj
+<< /Type /FontDescriptor /FontName /ANGBFD+TeXGyreCursor-Regular /Flags 4 /FontBBox [ -525 -250 1094 951 ] /Ascent 951 /CapHeight 563 /Descent -250 /ItalicAngle 0 /StemV 200 /XHeight 417 /FontFile3 11 0 R /CIDSet 10 0 R >>
+endobj
+12 0 obj
+<< /Length 754 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ANGBFD-TeXGyreCursor-Regular-0)
+%%Title: (TeX-ANGBFD-TeXGyreCursor-Regular-0 TeX ANGBFD-TeXGyreCursor-Regular 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ANGBFD-TeXGyreCursor-Regular)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-ANGBFD-TeXGyreCursor-Regular def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+4 beginbfchar
+<0033> <0065>
+<0063> <0073>
+<0069> <0054>
+<006A> <0074>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ANGBFD+TeXGyreCursor-Regular /DescendantFonts [ 13 0 R ] /ToUnicode 12 0 R >>
+endobj
+13 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ANGBFD+TeXGyreCursor-Regular /FontDescriptor 9 0 R /W 8 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+14 0 obj
+[ 51 [ 444 ] 99 [ 389 ] 105 [ 611 278 ] ]
+endobj
+16 0 obj
+<< /Length 14 >>         
+[BINARY STREAM]
+endobj
+17 0 obj
+<< /Subtype /CIDFontType0C /Length 930 >>        
+[BINARY STREAM]
+endobj
+15 0 obj
+<< /Type /FontDescriptor /FontName /UJHTDY+TeXGyreTermes-Regular /Flags 4 /FontBBox [ -526 -281 1306 1055 ] /Ascent 1055 /CapHeight 662 /Descent -281 /ItalicAngle 0 /StemV 83 /XHeight 450 /FontFile3 17 0 R /CIDSet 16 0 R >>
+endobj
+18 0 obj
+<< /Length 754 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-UJHTDY-TeXGyreTermes-Regular-0)
+%%Title: (TeX-UJHTDY-TeXGyreTermes-Regular-0 TeX UJHTDY-TeXGyreTermes-Regular 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (UJHTDY-TeXGyreTermes-Regular)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-UJHTDY-TeXGyreTermes-Regular def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+4 beginbfchar
+<0033> <0065>
+<0063> <0073>
+<0069> <0054>
+<006A> <0074>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /UJHTDY+TeXGyreTermes-Regular /DescendantFonts [ 19 0 R ] /ToUnicode 18 0 R >>
+endobj
+19 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /UJHTDY+TeXGyreTermes-Regular /FontDescriptor 15 0 R /W 14 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+20 0 obj
+[ 51 [ 556 ] 99 [ 500 ] 105 [ 611 278 ] ]
+endobj
+22 0 obj
+<< /Length 14 >>         
+[BINARY STREAM]
+endobj
+23 0 obj
+<< /Subtype /CIDFontType0C /Length 830 >>        
+[BINARY STREAM]
+endobj
+21 0 obj
+<< /Type /FontDescriptor /FontName /VULFFJ+TeXGyreHeros-Regular /Flags 4 /FontBBox [ -529 -284 1353 1148 ] /Ascent 1148 /CapHeight 729 /Descent -284 /ItalicAngle 0 /StemV 93 /XHeight 524 /FontFile3 23 0 R /CIDSet 22 0 R >>
+endobj
+24 0 obj
+<< /Length 749 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-VULFFJ-TeXGyreHeros-Regular-0)
+%%Title: (TeX-VULFFJ-TeXGyreHeros-Regular-0 TeX VULFFJ-TeXGyreHeros-Regular 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (VULFFJ-TeXGyreHeros-Regular)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-VULFFJ-TeXGyreHeros-Regular def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+4 beginbfchar
+<0033> <0065>
+<0063> <0073>
+<0069> <0054>
+<006A> <0074>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /VULFFJ+TeXGyreHeros-Regular /DescendantFonts [ 25 0 R ] /ToUnicode 24 0 R >>
+endobj
+25 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /VULFFJ+TeXGyreHeros-Regular /FontDescriptor 21 0 R /W 20 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+7 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 2 0 R ] >>
+endobj
+26 0 obj
+<< /Type /Catalog /Pages 7 0 R >>
+endobj
+27 0 obj
+<< /Producer (LuaTeX) /Creator (TeX) /Trapped /False >>
+endobj
+xref
+0 28
+0000000000 65535 f 
+0000001097 00000 n 
+0000000983 00000 n 
+0000000020 00000 n 
+0000008442 00000 n 
+0000005987 00000 n 
+0000003428 00000 n 
+0000008801 00000 n 
+0000001187 00000 n 
+0000002376 00000 n 
+0000001244 00000 n 
+0000001318 00000 n 
+0000002614 00000 n 
+0000003585 00000 n 
+0000003787 00000 n 
+0000004933 00000 n 
+0000003845 00000 n 
+0000003919 00000 n 
+0000005173 00000 n 
+0000006144 00000 n 
+0000006348 00000 n 
+0000007394 00000 n 
+0000006406 00000 n 
+0000006480 00000 n 
+0000007633 00000 n 
+0000008598 00000 n 
+0000008861 00000 n 
+0000008911 00000 n 
+trailer
+<< /Size 28 /Root 26 0 R /Info 27 0 R >>
+startxref
+8983
+%%EOF

--- a/testfiles/colour-model.pvt
+++ b/testfiles/colour-model.pvt
@@ -1,0 +1,35 @@
+\input{fontspec-testsetup.tex}
+\usepackage{fontspec}
+\ExplSyntaxOn
+ \color_set:nnn{cmyk}{cmyk}{1,0,0.5,0}
+\ExplSyntaxOff
+
+\begin{document}
+
+\fontspec[Color=00FF00]{texgyreheros-regular.otf} Test 
+
+\fontspec[Color=red]{texgyreheros-regular.otf} Test
+
+\fontspec[Color=cmyk]{texgyreheros-regular.otf} Test 
+
+\ExplSyntaxOn
+\tl_set:Nn \l_color_fixed_model_tl{rgb}
+\ExplSyntaxOff 
+
+\fontspec[Color=00FF00]{texgyretermes-regular.otf} Test 
+
+\fontspec[Color=red]{texgyretermes-regular.otf} Test
+
+\fontspec[Color=cmyk]{texgyretermes-regular.otf} Test 
+
+\ExplSyntaxOn
+\tl_set:Nn \l_color_fixed_model_tl{cmyk}
+\ExplSyntaxOff 
+
+\fontspec[Color=00FF00]{texgyrecursor-regular.otf} Test 
+
+\fontspec[Color=red]{texgyrecursor-regular.otf} Test
+
+\fontspec[Color=cmyk]{texgyrecursor-regular.otf} Test 
+
+\end{document}

--- a/testfiles/colour-model.tpf
+++ b/testfiles/colour-model.tpf
@@ -1,0 +1,253 @@
+%PDF-1.5
+%дрнш
+19 0 obj
+<</Length 1104>>
+stream
+ q 1 0 0 1 72 98.079 cm 0 G 0 g 0 1 0 RG 0 1 0 rg q /Xtx_Gs_00000000 gs  BT /F1 9.9626 Tf -42.883 47.864 Td[<0069>94<00330063>5<006a>]TJ ET Q 0 G 0 g 1 0 0 RG 1 0 0 rg q /Xtx_Gs_00000001 gs  BT /F1 9.9626 Tf -42.883 35.909 Td[<0069>94<00330063>5<006a>]TJ ET Q 0 G 0 g 0 1 0.502 RG 0 1 0.502 rg q /Xtx_Gs_00000002 gs  BT /F1 9.9626 Tf -42.883 23.954 Td[<0069>94<00330063>5<006a>]TJ ET Q 0 G 0 g 0 1 0 RG 0 1 0 rg q /Xtx_Gs_00000003 gs  BT /F3 9.9626 Tf -42.883 11.999 Td[<0069>84<00330063>15<006a>]TJ ET Q 0 G 0 g 1 0 0 RG 1 0 0 rg q /Xtx_Gs_00000004 gs  BT /F3 9.9626 Tf -42.883 .043 Td[<0069>84<00330063>15<006a>]TJ ET Q 0 G 0 g 0 1 0.502 RG 0 1 0.502 rg q /Xtx_Gs_00000005 gs  BT /F3 9.9626 Tf -42.883 -11.912 Td[<0069>84<00330063>15<006a>]TJ ET Q 0 G 0 g 0 1 0 RG 0 1 0 rg q /Xtx_Gs_00000006 gs  BT /F5 9.9626 Tf -42.883 -23.867 Td[<006900330063006a>]TJ ET Q 0 G 0 g 1 0 0 RG 1 0 0 rg q /Xtx_Gs_00000007 gs  BT /F5 9.9626 Tf -42.883 -35.822 Td[<006900330063006a>]TJ ET Q 0 G 0 g 0 1 0.502 RG 0 1 0.502 rg q /Xtx_Gs_00000008 gs  BT /F5 9.9626 Tf -42.883 -47.777 Td[<006900330063006a>]TJ ET Q 0 G 0 g Q
+endstream
+endobj
+20 0 obj
+<</ExtGState<</Xtx_Gs_00000000 4 0 R/Xtx_Gs_00000001 7 0 R/Xtx_Gs_00000002 8 0 R/Xtx_Gs_00000003
+9 0 R/Xtx_Gs_00000004 12 0 R/Xtx_Gs_00000005 13 0 R/Xtx_Gs_00000006 14 0 R/Xtx_Gs_00000007
+17 0 R/Xtx_Gs_00000008 18 0 R>>/Font<</F1 5 0 R/F3 10 0 R/F5 15 0 R>>/ProcSet[/PDF/Text/ImageC/ImageB/ImageI]>>
+endobj
+3 0 obj
+<</Resources 20 0 R/Type/Page/Parent 21 0 R/Contents[19 0 R]>>
+endobj
+21 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]/MediaBox[0 0 255.12 170.08]>>
+endobj
+2 0 obj
+<</Creator(TeX)/Producer(xdvipdfmx)/CreationDate(D:20160520090000-00'00')>>
+endobj
+1 0 obj
+<</Pages 21 0 R/Type/Catalog>>
+endobj
+22 0 obj
+<</Length 401>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /EXQIVM+TeXGyreHeros-Regular-UTF16 def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+4 beginbfchar
+<0033> <0065>
+<0063> <0073>
+<0069> <0054>
+<006A> <0074>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+23 0 obj
+<</Length 402>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /XUUPUX+TeXGyreTermes-Regular-UTF16 def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+4 beginbfchar
+<0033> <0065>
+<0063> <0073>
+<0069> <0054>
+<006A> <0074>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+24 0 obj
+<</Length 402>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /POGXIQ+TeXGyreCursor-Regular-UTF16 def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+4 beginbfchar
+<0033> <0065>
+<0063> <0073>
+<0069> <0054>
+<006A> <0074>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+26 0 obj
+<</Subtype/CIDFontType0C/Length 809>>
+[BINARY STREAM]
+endobj
+27 0 obj
+[51[556]99[500]105[611 278]]
+endobj
+28 0 obj
+<</Length 14>>
+[BINARY STREAM]
+endobj
+30 0 obj
+<</Subtype/CIDFontType0C/Length 909>>
+[BINARY STREAM]
+endobj
+31 0 obj
+[51[444]99[389]105[611 278]]
+endobj
+32 0 obj
+<</Length 14>>
+[BINARY STREAM]
+endobj
+34 0 obj
+<</Subtype/CIDFontType0C/Length 953>>
+[BINARY STREAM]
+endobj
+35 0 obj
+[51[600]99[600]105[600 600]]
+endobj
+36 0 obj
+<</Length 14>>
+[BINARY STREAM]
+endobj
+6 0 obj
+<</Type/Font/Subtype/CIDFontType0/BaseFont/EXQIVM+TeXGyreHeros-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement
+0>>/FontDescriptor 25 0 R/DW 280/W 27 0 R>>
+endobj
+25 0 obj
+<</Type/FontDescriptor/Ascent 784/Descent -216/StemV 93/CapHeight 784/AvgWidth 534/FontBBox[-529
+-284 1353 1148]/ItalicAngle 0/Flags 6/Style<</Panose<000000000500000000000000>>>/FontName/EXQIVM+TeXGyreHeros-Regular/FontFile3
+26 0 R/CIDSet 28 0 R>>
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/EXQIVM+TeXGyreHeros-Regular-Identity-H/Encoding/Identity-H/DescendantFonts[6 0 R]/ToUnicode
+22 0 R>>
+endobj
+11 0 obj
+<</Type/Font/Subtype/CIDFontType0/BaseFont/XUUPUX+TeXGyreTermes-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement
+0>>/FontDescriptor 29 0 R/DW 280/W 31 0 R>>
+endobj
+29 0 obj
+<</Type/FontDescriptor/Ascent 783/Descent -217/StemV 102/CapHeight 783/AvgWidth 503/FontBBox[-526
+-281 1306 1055]/ItalicAngle 0/Flags 6/Style<</Panose<000000000500000000000000>>>/FontName/XUUPUX+TeXGyreTermes-Regular/FontFile3
+30 0 R/CIDSet 32 0 R>>
+endobj
+10 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/XUUPUX+TeXGyreTermes-Regular-Identity-H/Encoding/Identity-H/DescendantFonts[11 0 R]/ToUnicode
+23 0 R>>
+endobj
+16 0 obj
+<</Type/Font/Subtype/CIDFontType0/BaseFont/POGXIQ+TeXGyreCursor-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement
+0>>/FontDescriptor 33 0 R/DW 280/W 35 0 R>>
+endobj
+33 0 obj
+<</Type/FontDescriptor/Ascent 814/Descent -186/StemV 41/CapHeight 814/AvgWidth 579/FontBBox[-525
+-250 1094 951]/ItalicAngle 0/Flags 7/Style<</Panose<000000000509000000000000>>>/FontName/POGXIQ+TeXGyreCursor-Regular/FontFile3
+34 0 R/CIDSet 36 0 R>>
+endobj
+15 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/POGXIQ+TeXGyreCursor-Regular-Identity-H/Encoding/Identity-H/DescendantFonts[16 0 R]/ToUnicode
+24 0 R>>
+endobj
+4 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+7 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+8 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+9 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+12 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+13 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+14 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+17 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+18 0 obj
+<</Type/ExtGState/ca 1/CA 1>>
+endobj
+xref
+0 37
+0000000000 65535 f 
+0000001735 00000 n 
+0000001644 00000 n 
+0000001486 00000 n 
+0000008183 00000 n 
+0000006803 00000 n 
+0000006347 00000 n 
+0000008228 00000 n 
+0000008273 00000 n 
+0000008318 00000 n 
+0000007415 00000 n 
+0000006955 00000 n 
+0000008363 00000 n 
+0000008409 00000 n 
+0000008455 00000 n 
+0000008028 00000 n 
+0000007570 00000 n 
+0000008501 00000 n 
+0000008547 00000 n 
+0000000015 00000 n 
+0000001170 00000 n 
+0000001564 00000 n 
+0000001781 00000 n 
+0000002232 00000 n 
+0000002684 00000 n 
+0000006539 00000 n 
+0000003136 00000 n 
+0000004017 00000 n 
+0000004062 00000 n 
+0000007149 00000 n 
+0000004125 00000 n 
+0000005106 00000 n 
+0000005151 00000 n 
+0000007764 00000 n 
+0000005214 00000 n 
+0000006239 00000 n 
+0000006284 00000 n 
+trailer
+<</ID[<ID-STRING><ID-STRING>]/Root
+1 0 R/Info 2 0 R/Size 37>>
+startxref
+8593
+%%EOF

--- a/testfiles/colour-opacity.luatex.tlg
+++ b/testfiles/colour-opacity.luatex.tlg
@@ -1,10 +1,10 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 TU/texgyreheros-regular.otf(0)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={red};
 TU/texgyreheros-regular.otf(1)/m/n:
-  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=FF00007f;
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={red,7f};
 TU/texgyreheros-regular.otf(2)/m/n:
-  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=00FF007f;
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={00FF00,7f};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/colour-opacity.luatex.tlg
+++ b/testfiles/colour-opacity.luatex.tlg
@@ -6,5 +6,9 @@ TU/texgyreheros-regular.otf(1)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={red,7f};
 TU/texgyreheros-regular.otf(2)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={00FF00,7f};
+TU/texgyreheros-regular.otf(3)/m/n:
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={00FF0044};
+TU/texgyreheros-regular.otf(4)/m/n:
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={00FF00,4c};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/colour-opacity.lvt
+++ b/testfiles/colour-opacity.lvt
@@ -19,4 +19,14 @@ Test
 Test
 \CURRNFSS
 
+\fontspec[
+    Color=00FF0044
+      ]{texgyreheros-regular.otf}
+Test \CURRNFSS 
+
+\fontspec[
+    Color=00FF0044, Opacity=0.3
+      ]{texgyreheros-regular.otf}
+Test \CURRNFSS 
+
 \end{document}

--- a/testfiles/colour-opacity.tlg
+++ b/testfiles/colour-opacity.tlg
@@ -6,5 +6,9 @@ TU/texgyreheros-regular.otf(1)/m/n:
   "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=FF00007f;" at 10.0pt
 TU/texgyreheros-regular.otf(2)/m/n:
   "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=00FF007f;" at 10.0pt
+TU/texgyreheros-regular.otf(3)/m/n:
+  "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=00FF0044;" at 10.0pt
+TU/texgyreheros-regular.otf(4)/m/n:
+  "[texgyreheros-regular.otf]/OT:script=latn;language=dflt;color=00FF004c;" at 10.0pt
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/colour-spotcolor.luatex.tpf
+++ b/testfiles/colour-spotcolor.luatex.tpf
@@ -1,0 +1,113 @@
+%PDF-1.5
+%Ã’¡‘≈ÿ–ƒ∆
+1 0 obj
+<< /FunctionType 2/Domain [0 1]/C0 [0 0 0 0] /C1 [1 0.56 0 0]/N 1 >>
+endobj
+2 0 obj
+[ /Separation/PANTONE#203005#20U /DeviceCMYK 1 0 R ]
+endobj
+5 0 obj
+<< /Length 113 >>        
+stream
+/color1 cs 1.0 scn /color1 CS 1.0 SCN
+BT
+/F27 9.96264 Tf
+1 0 0 1 29.117 145.943 Tm [<006900690069>]TJ
+0 g 0 G
+ET
+endstream
+endobj
+4 0 obj
+<< /Type /Page /Contents 5 0 R /Resources 3 0 R /MediaBox [ 0 0 255.118 170.079 ] /Parent 7 0 R >>
+endobj
+3 0 obj
+<< /Font << /F27 6 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+8 0 obj
+[ 105 [ 611 ] ]
+endobj
+10 0 obj
+<< /Length 14 >>         
+[BINARY STREAM]
+endobj
+11 0 obj
+<< /Subtype /CIDFontType0C /Length 605 >>        
+[BINARY STREAM]
+endobj
+9 0 obj
+<< /Type /FontDescriptor /FontName /GYUAGU+TeXGyreTermes-Regular /Flags 4 /FontBBox [ -526 -281 1306 1055 ] /Ascent 1055 /CapHeight 662 /Descent -281 /ItalicAngle 0 /StemV 83 /XHeight 450 /FontFile3 11 0 R /CIDSet 10 0 R >>
+endobj
+12 0 obj
+<< /Length 712 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-GYUAGU-TeXGyreTermes-Regular-0)
+%%Title: (TeX-GYUAGU-TeXGyreTermes-Regular-0 TeX GYUAGU-TeXGyreTermes-Regular 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (GYUAGU-TeXGyreTermes-Regular)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-GYUAGU-TeXGyreTermes-Regular def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+1 beginbfchar
+<0069> <0054>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /GYUAGU+TeXGyreTermes-Regular /DescendantFonts [ 13 0 R ] /ToUnicode 12 0 R >>
+endobj
+13 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /GYUAGU+TeXGyreTermes-Regular /FontDescriptor 9 0 R /W 8 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+7 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 4 0 R ] >>
+endobj
+14 0 obj
+<< /Type /Catalog /Pages 7 0 R >>
+endobj
+15 0 obj
+<< /Producer (LuaTeX) /Creator (TeX) /Trapped /False >>
+endobj
+xref
+0 16
+0000000000 65535 f 
+0000000020 00000 n 
+0000000104 00000 n 
+0000000458 00000 n 
+0000000344 00000 n 
+0000000172 00000 n 
+0000002331 00000 n 
+0000002690 00000 n 
+0000000526 00000 n 
+0000001320 00000 n 
+0000000557 00000 n 
+0000000631 00000 n 
+0000001559 00000 n 
+0000002488 00000 n 
+0000002750 00000 n 
+0000002800 00000 n 
+trailer
+<< /Size 16 /Root 14 0 R /Info 15 0 R >>
+startxref
+2872
+%%EOF

--- a/testfiles/colour-spotcolor.pvt
+++ b/testfiles/colour-spotcolor.pvt
@@ -1,0 +1,19 @@
+\input{fontspec-testsetup.tex}
+\usepackage{fontspec,iftex}
+\ExplSyntaxOn
+ \color_model_new:nnn { sepblue } { Separation }
+    {
+      name = PANTONE~3005~U ,
+      alternative-model = cmyk ,
+      alternative-values = {1, 0.56, 0,0},
+    }
+  \color_set:nnn{spotblue}{sepblue}{1}
+\ExplSyntaxOff
+
+\ifluatex 
+\setmainfont{texgyretermes}[Color=spotblue] 
+\fi 
+
+\begin{document}
+ TTT 
+\end{document}

--- a/testfiles/colour-spotcolor.tpf
+++ b/testfiles/colour-spotcolor.tpf
@@ -1,0 +1,98 @@
+%PDF-1.5
+%дрнш
+7 0 obj
+<</Length 90>>
+stream
+ q 1 0 0 1 72 98.079 cm 0 G 0 g BT /F1 9.9626 Tf -42.883 47.864 Td[<006800680068>]TJ ET Q
+endstream
+endobj
+8 0 obj
+<</Font<</F1 5 0 R>>/ProcSet[/PDF/Text/ImageC/ImageB/ImageI]>>
+endobj
+4 0 obj
+<</FunctionType 2/Domain[0 1]/C0[0 0 0 0]/C1[1 .56 0 0]/N 1>>
+endobj
+3 0 obj
+<</Resources 8 0 R/Type/Page/Parent 9 0 R/Contents[7 0 R]>>
+endobj
+9 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]/MediaBox[0 0 255.12 170.08]>>
+endobj
+2 0 obj
+<</Creator(TeX)/Producer(xdvipdfmx)/CreationDate(D:20160520090000-00'00')>>
+endobj
+1 0 obj
+<</Pages 9 0 R/Type/Catalog>>
+endobj
+10 0 obj
+<</Length 356>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /EXQIVM+LMRoman10-Regular-UTF16 def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfchar
+<0068> <0054>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+12 0 obj
+<</Subtype/CIDFontType0C/Length 596>>
+[BINARY STREAM]
+endobj
+13 0 obj
+[104[722]]
+endobj
+14 0 obj
+<</Length 14>>
+[BINARY STREAM]
+endobj
+6 0 obj
+<</Type/Font/Subtype/CIDFontType0/BaseFont/EXQIVM+LMRoman10-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement
+0>>/FontDescriptor 11 0 R/DW 280/W 13 0 R>>
+endobj
+11 0 obj
+<</Type/FontDescriptor/Ascent 806/Descent -194/StemV 69/CapHeight 806/AvgWidth 549/FontBBox[-430
+-290 1417 1127]/ItalicAngle 0/Flags 6/Style<</Panose<000000000500000000000000>>>/FontName/EXQIVM+LMRoman10-Regular/FontFile3
+12 0 R/CIDSet 14 0 R>>
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/EXQIVM+LMRoman10-Regular-Identity-H/Encoding/Identity-H/DescendantFonts[6 0 R]/ToUnicode
+10 0 R>>
+endobj
+xref
+0 15
+0000000000 65535 f 
+0000000553 00000 n 
+0000000462 00000 n 
+0000000308 00000 n 
+0000000231 00000 n 
+0000002212 00000 n 
+0000001762 00000 n 
+0000000015 00000 n 
+0000000153 00000 n 
+0000000383 00000 n 
+0000000598 00000 n 
+0000001951 00000 n 
+0000001004 00000 n 
+0000001672 00000 n 
+0000001699 00000 n 
+trailer
+<</ID[<ID-STRING><ID-STRING>]/Root
+1 0 R/Info 2 0 R/Size 15>>
+startxref
+2361
+%%EOF

--- a/testfiles/fontface-spaces.luatex.tlg
+++ b/testfiles/fontface-spaces.luatex.tlg
@@ -7,6 +7,6 @@ TU/texgyretermes-regular.otf(0)/m/it:
 TU/texgyretermes-regular.otf(0)/blub/it:
   [texgyrecursor-italic.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyretermes-regular.otf(0)/c/n:
-  "[texgyrebonum-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;"
+  [texgyrebonum-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-defaults-adding.luatex.tlg
+++ b/testfiles/fontload-defaults-adding.luatex.tlg
@@ -4,9 +4,9 @@ Don't change this file in any respect.
 All font defaults
 =================
 TU/texgyrepagella-regular.otf(0)/m/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;color=00AA00FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;color={00AA00};
 TU/texgyreheros-regular.otf(0)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;color=00AA00FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;color={00AA00};
 TU/texgyrepagella-regular.otf(1)/m/n:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyreheros-regular.otf(1)/m/n:
@@ -14,12 +14,12 @@ TU/texgyreheros-regular.otf(1)/m/n:
 TU/texgyrepagella-regular.otf(2)/m/n:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;
 TU/texgyreheros-regular.otf(0)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;color=00AA00FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+smcp;+tlig;color={00AA00};
 =================
 Family specific
 =================
 TU/texgyrepagella-regular.otf(3)/m/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color=00AA00FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color={00AA00};
 TU/texgyreheros-regular.otf(1)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella-regular.otf(4)/m/n:
@@ -27,7 +27,7 @@ TU/texgyrepagella-regular.otf(4)/m/n:
 TU/texgyreheros-regular.otf(1)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella-regular.otf(3)/m/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color=00AA00FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color={00AA00};
 TU/texgyreheros-regular.otf(1)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 ***************

--- a/testfiles/fontload-defaults.luatex.tlg
+++ b/testfiles/fontload-defaults.luatex.tlg
@@ -8,9 +8,9 @@ TU/texgyreheros-regular.otf(0)/m/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TT:
 TU/texgyrecursor-regular.otf(0)/m/n:
-  "[texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt;color={red};
 "CODE":
 TU/texgyrecursor-regular.otf(1)/m/n:
-  "[texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt;color=0000FFFF ;"
+  [texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt;color={blue};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-fontface-1.luatex.tlg
+++ b/testfiles/fontload-fontface-1.luatex.tlg
@@ -3,7 +3,7 @@ Don't change this file in any respect.
 TU/texgyre(0)/m/n:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyre(0)/c/n:
-  "[texgyrebonum-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;"
+  [texgyrebonum-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000};
 TU/texgyre(0)/nc/n:
   [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 ***************

--- a/testfiles/fontload-fontface-2-sc.luatex.tlg
+++ b/testfiles/fontload-fontface-2-sc.luatex.tlg
@@ -6,24 +6,24 @@ TU/texgyrepagella-regular.otf(0)/m/n:
 TU/texgyrepagella-regular.otf(0)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella-regular.otf(0)/col1/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000};
 TU/texgyrepagella-regular.otf(0)/col1/sc:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=FF0000FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={FF0000};
 TU/texgyrepagella-regular.otf(0)/col2/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=0000FFFF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={0000FF};
 TU/texgyrepagella-regular.otf(0)/col2/sc:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=0000FFFF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={0000FF};
 SHAPE (sc shapes not defined; falls back to default)
 TU/texgyrepagella-regular.otf(1)/m/n:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;
 TU/texgyrepagella-regular.otf(1)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella-regular.otf(1)/m/col1:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000};
 TU/texgyrepagella-regular.otf(1)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella-regular.otf(1)/m/col2:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=0000FFFF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={0000FF};
 TU/texgyrepagella-regular.otf(1)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 ***************

--- a/testfiles/fontload-fontface-3-sizing.luatex.tlg
+++ b/testfiles/fontload-fontface-3-sizing.luatex.tlg
@@ -2,31 +2,31 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 NORMAL
 TU/SourceCodePro-Regular.otf(0)/m/n:
-  "[SourceCodePro-Medium.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 5.0pt
+  [SourceCodePro-Medium.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 5.0pt
 TU/SourceCodePro-Regular.otf(0)/m/n:
-  "[SourceCodePro-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;"
+  [SourceCodePro-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00};
 TU/SourceCodePro-Regular.otf(0)/m/n:
-  "[SourceCodePro-Light.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 24.88pt
+  [SourceCodePro-Light.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 24.88pt
 ITALIC
 TU/SourceCodePro-Regular.otf(0)/m/it:
-  "[SourceCodePro-RegularIt.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 5.0pt
+  [SourceCodePro-RegularIt.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 5.0pt
 TU/SourceCodePro-Regular.otf(0)/m/it:
-  "[SourceCodePro-RegularIt.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;"
+  [SourceCodePro-RegularIt.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00};
 TU/SourceCodePro-Regular.otf(0)/m/it:
-  "[SourceCodePro-RegularIt.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 24.88pt
+  [SourceCodePro-RegularIt.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 24.88pt
 FONTSERIES C
 TU/SourceCodePro-Regular.otf(0)/c/n:
-  "[SourceCodePro-MediumIt.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;" at 5.0pt
+  [SourceCodePro-MediumIt.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000}; at 5.0pt
 TU/SourceCodePro-Regular.otf(0)/c/n:
-  "[texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF00FFFF ;"
+  [texgyrecursor-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF00FF};
 TU/SourceCodePro-Regular.otf(0)/c/n:
-  "[SourceCodePro-LightIt.otf]:mode=node;script=latn;language=dflt;+tlig;color=0000FFFF ;" at 24.88pt
+  [SourceCodePro-LightIt.otf]:mode=node;script=latn;language=dflt;+tlig;color={0000FF}; at 24.88pt
 FONTSERIES NC
 TU/SourceCodePro-Regular.otf(0)/nc/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 5.0pt
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 5.0pt
 TU/SourceCodePro-Regular.otf(0)/nc/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00};
 TU/SourceCodePro-Regular.otf(0)/nc/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 24.88pt
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 24.88pt
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-fontspec-file-case.luatex.tlg
+++ b/testfiles/fontload-fontspec-file-case.luatex.tlg
@@ -2,12 +2,12 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 Fira Sans:
 TU/FiraSans-Regular.otf(0)/m/n:
-  "[FiraSans-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=AABBCCFF ;"
+  [FiraSans-Regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={AABBCC};
 TU/FiraSans-Regular.otf(0)/m/it:
-  "[FiraSans-Italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=AABBCCFF ;"
+  [FiraSans-Italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={AABBCC};
 TU/FiraSans-Regular.otf(0)/b/n:
-  "[FiraSans-Bold.otf]:mode=node;script=latn;language=dflt;+tlig;color=AABBCCFF ;"
+  [FiraSans-Bold.otf]:mode=node;script=latn;language=dflt;+tlig;color={AABBCC};
 TU/FiraSans-Regular.otf(0)/b/it:
-  "[FiraSans-BoldItalic.otf]:mode=node;script=latn;language=dflt;+tlig;color=AABBCCFF ;"
+  [FiraSans-BoldItalic.otf]:mode=node;script=latn;language=dflt;+tlig;color={AABBCC};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-fontspec-file.luatex.tlg
+++ b/testfiles/fontload-fontspec-file.luatex.tlg
@@ -2,18 +2,18 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 Bare bones colour red loaded from file:
 TU/texgyreschola-regular.otf(0)/m/n:
-  "[texgyreschola-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;"
+  [texgyreschola-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000};
 New font name, colour blue, loaded from file:
 TU/TeXGyreTermes(0)/m/n:
-  "[texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=0000FFFF ;"
+  [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={0000FF};
 A more comprehensive family (note nested defn for BI shape):
 TU/MyHeros(0)/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=119944FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={119944};
 TU/MyHeros(0)/b/n:
-  "[texgyreheros-bold.otf]:mode=node;script=latn;language=dflt;+tlig;color=119944FF ;"
+  [texgyreheros-bold.otf]:mode=node;script=latn;language=dflt;+tlig;color={119944};
 TU/MyHeros(0)/m/it:
-  "[texgyreheros-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=119944FF ;"
+  [texgyreheros-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={119944};
 TU/MyHeros(0)/b/it:
-  "[texgyreheros-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;color=223355FF ;"
+  [texgyreheros-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;color={223355};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-nfssfamily-1.luatex.tlg
+++ b/testfiles/fontload-nfssfamily-1.luatex.tlg
@@ -5,12 +5,12 @@ TU/lmr/m/n:
   [lmroman10-regular]:+tlig;
 Code with particular NFSS family font:
 TU/ABC/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={FF0000};
 Back to normal font:
 TU/lmr/m/n:
   [lmroman10-regular]:+tlig;
 Loading NFSS family explicit:
 TU/ABC/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={FF0000};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-nfssfamily-2.luatex.tlg
+++ b/testfiles/fontload-nfssfamily-2.luatex.tlg
@@ -12,12 +12,12 @@ TU/newfoo/m/n:
   [texgyreheros-regular.otf]:color=FFAA00
 USING FONTSPEC:
 TU/foo/m/n:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;color={FF0000};
 TU/foo/m/sc:
-  "[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color=FF0000FF ;"
+  [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color={FF0000};
 TU/foo/m/n:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color=FF00FFFF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;color={FF00FF};
 TU/foo/m/sc:
-  "[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color=FF00FFFF ;"
+  [texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color={FF00FF};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-scfeat-nesting.luatex.tlg
+++ b/testfiles/fontload-scfeat-nesting.luatex.tlg
@@ -1,20 +1,20 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 TU/texgyretermes(0)/m/n:
-  "[texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;color=220022FF ;"
+  [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;color={220022};
 TU/texgyretermes(0)/m/sc:
-  "[texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color=115511FF ;"
+  [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;+smcp;color={115511};
 TU/texgyretermes(0)/m/it:
-  "[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;color=2244FFFF ;"
+  [texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;color={2244FF};
 TU/texgyretermes(0)/m/scit:
-  "[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;+smcp;color=112299FF ;"
+  [texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;+smcp;color={112299};
 TU/texgyretermes(0)/b/n:
-  "[texgyretermes-bold.otf]:mode=node;script=latn;language=dflt;color=FF4422FF ;"
+  [texgyretermes-bold.otf]:mode=node;script=latn;language=dflt;color={FF4422};
 TU/texgyretermes(0)/b/sc:
-  "[texgyretermes-bold.otf]:mode=node;script=latn;language=dflt;+smcp;color=992211FF ;"
+  [texgyretermes-bold.otf]:mode=node;script=latn;language=dflt;+smcp;color={992211};
 TU/texgyretermes(0)/b/it:
-  "[texgyretermes-bolditalic.otf]:mode=node;script=latn;language=dflt;color=888844FF ;"
+  [texgyretermes-bolditalic.otf]:mode=node;script=latn;language=dflt;color={888844};
 TU/texgyretermes(0)/b/scit:
-  "[texgyretermes-bolditalic.otf]:mode=node;script=latn;language=dflt;+smcp;color=444422FF ;"
+  [texgyretermes-bolditalic.otf]:mode=node;script=latn;language=dflt;+smcp;color={444422};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-sizefeatures-1.luatex.tlg
+++ b/testfiles/fontload-sizefeatures-1.luatex.tlg
@@ -1,10 +1,10 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 TU/texgyrechorus-mediumitalic.otf(0)/m/n:
-  "[texgyrebonum-italic.otf]:mode=node;script=latn;language=dflt;color=AA0000FF ;" at 7.0pt
+  [texgyrebonum-italic.otf]:mode=node;script=latn;language=dflt;color={AA0000}; at 7.0pt
 TU/texgyrechorus-mediumitalic.otf(0)/m/n:
-  "[texgyrechorus-mediumitalic.otf]:mode=node;script=latn;language=dflt;color=00AA00FF ;"
+  [texgyrechorus-mediumitalic.otf]:mode=node;script=latn;language=dflt;color={00AA00};
 TU/texgyrechorus-mediumitalic.otf(0)/m/n:
-  "[texgyrechorus-mediumitalic.otf]:mode=node;script=latn;language=dflt;color=0000AAFF ;" at 14.4pt
+  [texgyrechorus-mediumitalic.otf]:mode=node;script=latn;language=dflt;color={0000AA}; at 14.4pt
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/fontload-sizefeatures-2-nesting.luatex.tlg
+++ b/testfiles/fontload-sizefeatures-2-nesting.luatex.tlg
@@ -1,20 +1,20 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-"[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=FF0000FF ;" at 9.0pt
-"[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=0000FFFF ;" at 9.0pt
-"[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color=00FF00FF ;" at 12.0pt
-"[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=FF00FFFF ;" at 12.0pt
-"[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=AA0000FF ;" at 9.0pt
-"[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=0000AAFF ;" at 9.0pt
-"[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color=00AA00FF ;" at 12.0pt
-"[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=AA00AAFF ;" at 12.0pt
-"[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;color=770000FF ;" at 9.0pt
-"[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=000077FF ;" at 9.0pt
-"[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;color=007700FF ;" at 12.0pt
-"[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=770077FF ;" at 12.0pt
-"[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;color=440000FF ;" at 9.0pt
-"[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=000044FF ;" at 9.0pt
-"[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;color=004400FF ;" at 12.0pt
-"[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color=440044FF ;" at 12.0pt
+[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={FF0000}; at 9.0pt
+[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={0000FF}; at 9.0pt
+[texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;color={00FF00}; at 12.0pt
+[texgyreheros-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={FF00FF}; at 12.0pt
+[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={AA0000}; at 9.0pt
+[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={0000AA}; at 9.0pt
+[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;color={00AA00}; at 12.0pt
+[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={AA00AA}; at 12.0pt
+[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;color={770000}; at 9.0pt
+[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={000077}; at 9.0pt
+[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;color={007700}; at 12.0pt
+[texgyrepagella-bold.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={770077}; at 12.0pt
+[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;color={440000}; at 9.0pt
+[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={000044}; at 9.0pt
+[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;color={004400}; at 12.0pt
+[texgyrepagella-bolditalic.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;color={440044}; at 12.0pt
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/italicfeatures-concat.luatex.tlg
+++ b/testfiles/italicfeatures-concat.luatex.tlg
@@ -5,8 +5,8 @@ TU/texgyrepagella(0)/m/n:
 TU/texgyrepagella(0)/m/sc:
   [texgyrepagella-regular.otf]:mode=node;script=latn;language=dflt;+tlig;+smcp;
 TU/texgyrepagella(0)/m/it:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;color={AA0000};
 TU/texgyrepagella(0)/m/scit:
-  "[texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;color=AA0000FF ;"
+  [texgyrepagella-italic.otf]:mode=node;script=latn;language=dflt;+tlig;+onum;+smcp;color={AA0000};
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/user-alias-feature.luatex.tlg
+++ b/testfiles/user-alias-feature.luatex.tlg
@@ -3,6 +3,6 @@ Don't change this file in any respect.
 TU/texgyretermes-regular.otf(0)/m/n:
   [texgyretermes-regular.otf]:mode=node;script=latn;language=dflt;
 TU/texgyretermes-regular.otf(0)/m/it:
-  "[texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;color=FF0000FF ;"
+  [texgyretermes-italic.otf]:mode=node;script=latn;language=dflt;color={FF0000};
 ***************
 Compilation 1 of test file completed with exit status 0


### PR DESCRIPTION
## Status
**READY**

## Description
Use new luaotfload functionality to support named colors from l3color and spotcolors/cmyk in LuaLaTeX.

## Todos
- [x] Tests added to cover new/fixed functionality
- [x] Documentation if necessary - Covered by existing documentation of color keys
- [x] Code follows expl3 style guidelines