### PR TITLE
Fix typos and add \DescribeOption in the documentation

### DIFF
--- a/fontspec-doc-fontsel.tex
+++ b/fontspec-doc-fontsel.tex
@@ -129,7 +129,7 @@ wish to have them all installed in your system's font directories.
 In this case, it is more convenient to load them from a different location on your disk.
 This technique is also necessary in \XeTeX\ when loading OpenType fonts that are present within your \TeX\ distribution, such as \path{/usr/local/texlive/2013/texmf-dist/fonts/opentype/public}.
 Fonts in such locations are visible to \XeTeX\ but cannot be loaded by font name, only file name; \LuaTeX\ does not have this restriction.
-(If you for some reason want to restrict the fonts to the ones provided by your \TeX\ distribution even though you are using \LuaTeX\ you can use the \texttt{KpseOnly} option)
+(If you for some reason want to restrict the fonts to the ones provided by your \TeX\ distribution even though you are using \LuaTeX\ you can use the \DescribeOption{KpseOnly}\texttt{KpseOnly} option)
 
 When selecting fonts by file name, any font that can be found in the default
 search paths may be used directly (including in the current directory)
@@ -231,7 +231,7 @@ To continue the example above, here we colour the different faces:
   \defaultfontfeatures[CharisSILR]{Color=blue}
   \defaultfontfeatures[CharisSILB]{Color=red}
 \end{Verbatim}
-Such configuration lines could be stored either inline inside \texttt{My Charis.fontspec}
+Such configuration lines could be stored either inline inside \texttt{MyCharis.fontspec}
 or within their own \texttt{.fontspec} files; in this way, \pkg{fontspec} is designed to
 handle `nested' configuration options.
 
@@ -366,9 +366,9 @@ in \exref{nfface}, which is repeated in \vref{sec:contextuals}.
 The automatic bold, italic, and bold italic font selections will not be
 adequate for the needs of every font: while some fonts mayn't even
 have bold or italic shapes, in which case a skilled (or lucky)
-designer may be able to chose well-matching accompanying shapes from
+designer may be able to choose well-matching accompanying shapes from
 a different font altogether, others can have a range of bold and
-italic fonts to chose among.  The \feat{BoldFont} and
+italic fonts to choose among.  The \feat{BoldFont} and
 \feat{ItalicFont} features are provided for these situations. If only
 one of these is used, the bold italic font is requested as the
 default from the \emph{new} font. See \exref{bff}.
@@ -429,7 +429,7 @@ Without these, however, the \LaTeX\ font switches for slanted (\cs{textsl}, \cs{
 
 Swash font shapes in a family is supported by \LaTeX's commands \cs{textsw} and \cs{swshape}. These commands assume that swash shapes are in a sense `parallel' to italic shapes --- for instance, writing both \cs{swshape} and \cs{itshape} would not result in an italic swash shape (you would get whichever was declared last).
 The \pkg{fontspec} package adopts this approach, while recognising that OpenType fonts in theory could have any crazy combination of shapes such as `italic swash small caps'.
-Attempting to support arbitrarily complex situations makes setup (and the code) more difficult with let's say infrequent benefit --- \pkg{fontspec}'s alternate feature selection mechanisms (such as verb|\addfontfeature{Style=Swash}|) can be used in such situations.
+Attempting to support arbitrarily complex situations makes setup (and the code) more difficult with let's say infrequent benefit --- \pkg{fontspec}'s alternate feature selection mechanisms (such as |\addfontfeature{Style=Swash}|) can be used in such situations.
 
 Therefore, setup is quite simple:
 \begin{Verbatim}

--- a/fontspec-doc-intro.tex
+++ b/fontspec-doc-intro.tex
@@ -77,7 +77,10 @@ For basic use, no package options are required:
 Package options will be introduced below; some preliminary details are discussed first.
 Package options are setup with the in-built \LaTeX{} keyval options handler. This means
 that the package can be loaded more than once with different options without triggering
-an option clash error. The \texttt{config} and \texttt{no-config} option must be used in
+an option clash error.
+\DescribeOption{config}
+\DescribeOption{no-config}
+The \texttt{config} and \texttt{no-config} option must be used in
 the first loading and are ignored later.
 
 \subsection{Font encodings}
@@ -86,6 +89,8 @@ The package switches the \textsc{nfss} font encoding to \texttt{TU}.
 \texttt{TU} is a new Unicode font encoding, intended for both \XeTeX\ and \LuaTeX\ engines, and automatically contains support for symbols covered by \LaTeX's traditional \texttt{T1} and \texttt{TS1} font encodings (for example, |\%|, |\textbullet|, |\"u|, and so on).
 Some additional features are provided by \pkg{fontspec} to customise some encoding details; see Part~\vref{part:enc} for further details.
 
+\DescribeOption{euenc}
+\DescribeOption{tuenc}
 Pre-2017 behaviour is now obsolete. The \texttt{euenc} and \texttt{tuenc} package options are
 ignored. Package authors and users who have referred explicitly to the encoding names \texttt{EU1} or \texttt{EU2} should update their code or documents.
 (See internal variable names described in \vref{sec:api} for how to do this properly.)
@@ -95,7 +100,7 @@ ignored. Package authors and users who have referred explicitly to the encoding 
 By default, \pkg{fontspec} adjusts \LaTeX's default maths setup in order to maintain the correct Computer Modern symbols when the roman font changes.
 However, it will attempt to avoid doing this if another maths font package is loaded (such as \pkg{mathpazo} or the \pkg{unicode-math} package).
 
-If you find that \pkg{fontspec} is incorrectly changing the maths font when it shouldn't be, apply the |no-math| package option to manually suppress its behaviour here.
+If you find that \pkg{fontspec} is incorrectly changing the maths font when it shouldn't be, apply the \DescribeOption{no-math} |no-math| package option to manually suppress its behaviour here.
 
 
 \subsection{Configuration}
@@ -110,6 +115,7 @@ A |fontspec.cfg| file is distributed with \pkg{fontspec} with a small number of 
 To customise \pkg{fontspec} to your liking, use the standard |.cfg| file as a starting point or write your own from scratch, then either place it in the same folder as the main document for isolated cases, or in a location
 that \XeTeX\ or \LuaTeX\ searches by default; \eg\ in Mac\TeX: \path{~/Library/texmf/tex/latex/}.
 
+\DescribeOption{no-config}
 The package option |no-config| will suppress the loading of the |fontspec.cfg| file under all circumstances. Both options must be used the first time \pkg{fontspec} is loaded and are ignored in later calls.
 
 
@@ -117,13 +123,14 @@ The package option |no-config| will suppress the loading of the |fontspec.cfg| f
 \label{sec:quiet-warnings}
 
 This package can give some warnings that can be harmless if you know what
-you're doing. Use the |quiet| package option to write these warnings to the
+you're doing. Use the \DescribeOption{quiet} |quiet| package option to write these warnings to the
 transcript (\texttt{.log}) file instead.
 
+\DescribeOption{silent}
 Use the |silent| package option to completely suppress these warnings if you
 don't even want the |.log| file cluttered up.
 
-Both options can also be used with \cs{Setkeys} in the document. Use the |verbose| option to get activate the warnings again.
+Both options can also be used with \cs{Setkeys} in the document. Use the \DescribeOption{verbose} |verbose| option to get activate the warnings again.
 
 \section{Interaction with \LaTeXe\ and other packages}
 


### PR DESCRIPTION
## Status
**READY**

## Description

+ Fix several typos
+ Add `\DescribeOption` for quicker search in the margin area

