### PR TITLE
Re-sync with `expl3` for deprecated commands

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -5,7 +5,7 @@ on:
   # Whenever someone pushes to a branch in our repo
   push:
     branches:
-      - "*"
+      - "**"
   # Whenever a pull request is opened, reopened or gets new commits.
   pull_request:
 # This implies that for every push to a local branch in our repo for which a

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
   # Whenever someone pushes to a branch in our repo
   push:
     branches:
-      - "*"
+      - "**"
   # Whenever a pull request is opened, reopened or gets new commits.
   pull_request:
 # This implies that for every push to a local branch in our repo for which a

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,6 +1,10 @@
 Change history
 ==============
 
+## v2.9c (2024/xx/xx)
+
+  * Re-sync with `expl3` for deprecated commands.
+
 ## v2.9b (2024/04/27)
 
   * Add new `Letters=Uppercase` (LuaLaTeX only) as an interface to `luaotfload`

--- a/fontspec-code-opening.dtx
+++ b/fontspec-code-opening.dtx
@@ -163,7 +163,7 @@
 %
 %    \begin{macrocode}
 \cs_generate_variant:Nn \int_set:Nn {Nv}
-\cs_generate_variant:Nn \prop_gput_if_new:Nnn  {NeV}
+\cs_generate_variant:Nn \prop_gput_if_not_in:Nnn {NeV}
 \cs_generate_variant:Nn \prop_gput:Nnn  {Nxn} % needed by unicode-math
 \cs_generate_variant:Nn \tl_if_empty:nF {f}
 \cs_generate_variant:Nn \tl_if_eq:nnT {oe}

--- a/fontspec-code-xfss.dtx
+++ b/fontspec-code-xfss.dtx
@@ -102,7 +102,7 @@
       \clist_map_inline:nn {\strongreset,#1}
         {
           ##1
-          \prop_gput_if_new:NeV \g_@@_strong_prop { \f@series } { \l_@@_strongdef_int }
+          \prop_gput_if_not_in:NeV \g_@@_strong_prop { \f@series } { \l_@@_strongdef_int }
           \prop_gput:Nen \g_@@_strong_prop { switch-\int_use:N \l_@@_strongdef_int } { ##1 }
           \int_incr:N \l_@@_strongdef_int
         }

--- a/testfiles/support/fontspec-testsetup.tex
+++ b/testfiles/support/fontspec-testsetup.tex
@@ -1,11 +1,6 @@
-
-\PassOptionsToPackage{check-declarations}{expl3}
-\PassOptionsToPackage{enable-debug}{expl3}
-
 \input{regression-test.tex}
 \documentclass{article}
 
-\usepackage[enable-debug]{expl3}
 \ExplSyntaxOn
 \debug_on:n {all}
 \ExplSyntaxOff


### PR DESCRIPTION
## Status

**READY**

## Description

Replace (soft-)deprecated l3kernel `\prop_gput_if_new:Nnn` with `\prop_gput_if_not_in:Nnn`, see
- latex3/latex3@a4f84501 (Rename \prop_(g)put_if_new:Nn to \prop_(g)put_if_not_in:Nn, 2024-03-30) and
- latex3/latex3@a4390cc9 (Avoid warnings for use of \prop_put_if_new: A temporary change until fontspec is updated., 2024-04-06)

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [x] Code follows expl3 style guidelines