### PR TITLE
Tidy up variants of expl3 functions

### DIFF
--- a/fontspec-code-internal.dtx
+++ b/fontspec-code-internal.dtx
@@ -344,8 +344,8 @@
         \tl_if_empty:NF \l_@@_script_name_tl
           {
 %<debug>  \typeout{:::: Script=\l_@@_script_name_tl, Language=\l_@@_lang_name_tl}
-            \keys_set:nx {fontspec-opentype} {Script=\l_@@_script_name_tl}
-            \keys_set:nx {fontspec-opentype} {Language=\l_@@_lang_name_tl}
+            \keys_set:ne {fontspec-opentype} {Script=\l_@@_script_name_tl}
+            \keys_set:ne {fontspec-opentype} {Language=\l_@@_lang_name_tl}
           }
       }
   }
@@ -557,7 +557,7 @@
 \cs_new:Nn \fontspec_complete_fontname:Nn
   {
     \tl_set:Nx #1 {#2}
-    \tl_replace_all:Nnx #1 {*} {\l_@@_basename_tl}
+    \tl_replace_all:Nne #1 {*} {\l_@@_basename_tl}
     \@@_process_ext:N #1
   }
 %    \end{macrocode}
@@ -573,13 +573,13 @@
   {
     \tl_set:Nx \l_@@_this_font_tl {#3}
 
-    \tl_if_empty:xTF {#4}
+    \tl_if_empty:eTF {#4}
       { \clist_set:Nn \l_@@_sizefeat_clist {Size={-}} }
       { \@@_keys_set_known:nxN {fontspec-preparse-nested} {#4} \l_@@_tmp_tl }
 
     \tl_if_empty:NF \l_@@_this_font_tl
       {
-        \prop_put:Nxx \l_@@_nfssfont_prop {#1/#2}
+        \prop_put:Nee \l_@@_nfssfont_prop {#1/#2}
           { {#1}{#2}{\l_@@_this_font_tl}{#4}{\l_@@_sizefeat_clist} }
       }
   }
@@ -662,7 +662,7 @@
   {
     \bool_if:NF \l_@@_external_bool
       {
-        \tl_if_empty:xF {#2}
+        \tl_if_empty:eF {#2}
           {
             \tl_if_empty:NT #1
               {
@@ -776,7 +776,7 @@
     \tl_clear:N \l_@@_size_tl
     \tl_set_eq:NN \l_@@_sizedfont_tl \l_@@_saved_fontname_tl % in case not spec'ed
 
-    \keys_set_known:nxN {fontspec-sizing} { \exp_after:wN \use:n #2 }
+    \keys_set_known:neN {fontspec-sizing} { \exp_after:wN \use:n #2 }
       \l_@@_sizing_leftover_clist
     \tl_if_empty:NT \l_@@_size_tl { \@@_error:n {no-size-info} }
 %<debug>\typeout{==~ size:~\l_@@_size_tl}

--- a/fontspec-code-keyval.dtx
+++ b/fontspec-code-keyval.dtx
@@ -273,12 +273,12 @@
             \seq_put_right:Nx \l_@@_bf_series_seq {\bfdefault}
           }
 
-        \tl_if_eq:oxT \g_@@_curr_series_tl {\bfdefault}
+        \tl_if_eq:oeT \g_@@_curr_series_tl {\bfdefault}
           {
             \tl_set_eq:NN \l_@@_fontname_bf_tl \l_@@_curr_bfname_tl
           }
 
-        \prop_put:NxV \l_@@_nfss_prop {BoldFont-\g_@@_curr_series_tl} \l_@@_curr_bfname_tl
+        \prop_put:NeV \l_@@_nfss_prop {BoldFont-\g_@@_curr_series_tl} \l_@@_curr_bfname_tl
 
 %<debug>\typeout{Setting~bold~font~"\l_@@_curr_bfname_tl"~with~series~"\g_@@_curr_series_tl"}
 
@@ -335,7 +335,7 @@
 \@@_keys_define_code:nnn {fontspec-preparse} {BoldFeatures}
   {
     \clist_put_right:Nn \l_@@_fontfeat_bf_clist {#1}
-%  \prop_put:NxV \l_@@_nfss_prop
+%  \prop_put:NeV \l_@@_nfss_prop
 %     {BoldFont-\g_@@_curr_series_tl} \l_@@_curr_bfname_tl
   }
 \@@_keys_define_code:nnn {fontspec-preparse} {ItalicFeatures}

--- a/fontspec-code-opening.dtx
+++ b/fontspec-code-opening.dtx
@@ -163,21 +163,9 @@
 %
 %    \begin{macrocode}
 \cs_generate_variant:Nn \int_set:Nn {Nv}
-\cs_generate_variant:Nn \keys_set:nn {nx}
-\cs_generate_variant:Nn \keys_set_known:nnN {nx}
-\cs_generate_variant:Nn \prop_put:Nnn {Nxx}
-\cs_generate_variant:Nn \prop_put:Nnn {NxV}
-\cs_generate_variant:Nn \prop_gput_if_new:Nnn  {NxV}
-\cs_generate_variant:Nn \prop_gput:Nnn  {Nxn}
-\cs_generate_variant:Nn \prop_get:NnNT  {NxN}
-\cs_generate_variant:Nn \prop_get:NnNTF {NxN}
-\cs_generate_variant:Nn \str_if_eq:nnTF {nv}
-\cs_generate_variant:Nn \tl_if_empty_p:n {e}
-\cs_generate_variant:Nn \tl_if_empty:nTF {x}
-\cs_generate_variant:Nn \tl_if_empty:nF {x}
+\cs_generate_variant:Nn \prop_gput_if_new:Nnn  {NeV}
 \cs_generate_variant:Nn \tl_if_empty:nF {f}
-\cs_generate_variant:Nn \tl_if_eq:nnT {ox}
-\cs_generate_variant:Nn \tl_replace_all:Nnn {Nnx}
+\cs_generate_variant:Nn \tl_if_eq:nnT {oe}
 %    \end{macrocode}
 %
 %

--- a/fontspec-code-opening.dtx
+++ b/fontspec-code-opening.dtx
@@ -164,6 +164,7 @@
 %    \begin{macrocode}
 \cs_generate_variant:Nn \int_set:Nn {Nv}
 \cs_generate_variant:Nn \prop_gput_if_new:Nnn  {NeV}
+\cs_generate_variant:Nn \prop_gput:Nnn  {Nxn} % needed by unicode-math
 \cs_generate_variant:Nn \tl_if_empty:nF {f}
 \cs_generate_variant:Nn \tl_if_eq:nnT {oe}
 %    \end{macrocode}

--- a/fontspec-code-xfss.dtx
+++ b/fontspec-code-xfss.dtx
@@ -102,8 +102,8 @@
       \clist_map_inline:nn {\strongreset,#1}
         {
           ##1
-          \prop_gput_if_new:NxV \g_@@_strong_prop { \f@series } { \l_@@_strongdef_int }
-          \prop_gput:Nxn \g_@@_strong_prop { switch-\int_use:N \l_@@_strongdef_int } { ##1 }
+          \prop_gput_if_new:NeV \g_@@_strong_prop { \f@series } { \l_@@_strongdef_int }
+          \prop_gput:Nen \g_@@_strong_prop { switch-\int_use:N \l_@@_strongdef_int } { ##1 }
           \int_incr:N \l_@@_strongdef_int
         }
     \group_end:
@@ -118,7 +118,7 @@
     \@nomath\strongenv
 
 %<debug> \typeout{Strong~ level:~\int_use:N \l_@@_strong_int}
-    \prop_get:NxNT \g_@@_strong_prop { \f@series } \l_@@_strong_tmp_tl
+    \prop_get:NeNT \g_@@_strong_prop { \f@series } \l_@@_strong_tmp_tl
       {
         \int_set:Nn \l_@@_strong_int { \l_@@_strong_tmp_tl }
 %<debug> \typeout{Series~ (\f@series)~ detected;~ new~ level:~\int_use:N \l_@@_strong_int}
@@ -126,7 +126,7 @@
 
     \int_incr:N \l_@@_strong_int
 
-    \prop_get:NxNTF \g_@@_strong_prop { switch-\int_use:N \l_@@_strong_int } \l_@@_strong_switch_tl
+    \prop_get:NeNTF \g_@@_strong_prop { switch-\int_use:N \l_@@_strong_int } \l_@@_strong_switch_tl
       { \l_@@_strong_switch_tl }
       {
         \int_zero:N \l_@@_strong_int


### PR DESCRIPTION
## Status

**READY**

## Description

This PR drops function variant generations that are already provided in recent `expl3` (aka `l3kernel`), and changes relevant uses of `x`-type expansion to `e`-type.

A whole `x`-to-`e` switch can be done later in separate commit/PR.

## Todos
- [ ] Tests added to cover new/fixed functionality
- [ ] Documentation if necessary
- [x] Code follows expl3 style guidelines

